### PR TITLE
Add `LoginSetupWorker`

### DIFF
--- a/lib/ex_money.ex
+++ b/lib/ex_money.ex
@@ -7,7 +7,7 @@ defmodule ExMoney do
     children = [
       supervisor(ExMoney.Endpoint, []),
       worker(ExMoney.Repo, []),
-      worker(ExMoney.Saltedge.TransactionsWorker, []),
+      worker(ExMoney.Saltedge.LoginSetupWorker, []),
     ]
 
     opts = [strategy: :one_for_one, name: ExMoney.Supervisor]

--- a/lib/ex_money/saltedge/account.ex
+++ b/lib/ex_money/saltedge/account.ex
@@ -9,10 +9,13 @@ defmodule ExMoney.Saltedge.Account do
     Enum.each(accounts, fn(account) ->
       account = Map.put(account, "saltedge_account_id", account["id"])
       account = Map.drop(account, ["id"])
+      account = Map.put(account, "saltedge_login_id", account["login_id"])
       existing_account = Account.by_saltedge_account_id(account["saltedge_account_id"]) |> Repo.one
 
-      if !existing_account do
-        account = Map.put(account, "saltedge_login_id", account["login_id"])
+      if existing_account do
+        changeset = Account.changeset(existing_account, account)
+        Repo.update!(changeset)
+      else
         changeset = Account.changeset(%Account{}, account)
         Repo.insert!(changeset)
       end

--- a/lib/ex_money/saltedge/login.ex
+++ b/lib/ex_money/saltedge/login.ex
@@ -3,9 +3,20 @@ defmodule ExMoney.Saltedge.Login do
   alias ExMoney.Repo
 
   def sync(user_id) do
-    logins = ExMoney.Saltedge.Client.request(:get, "logins")
+    logins = ExMoney.Saltedge.Client.request(:get, "logins")["data"]
 
-    Enum.each(logins["data"], fn(login) ->
+    store_or_update_logins(logins, user_id)
+  end
+
+  def sync(user_id, login_id) do
+    login_url = "logins/#{login_id}"
+    login = ExMoney.Saltedge.Client.request(:get, login_url)["data"]
+
+    store_or_update_logins([login], user_id)
+  end
+
+  defp store_or_update_logins(logins, user_id) do
+    Enum.each(logins, fn(login) ->
       login = Map.put(login, "saltedge_login_id", login["id"])
       login = Map.drop(login, ["id"])
       login = Map.put(login, "user_id", user_id)

--- a/lib/ex_money/saltedge/login_setup_worker.ex
+++ b/lib/ex_money/saltedge/login_setup_worker.ex
@@ -1,0 +1,48 @@
+defmodule ExMoney.Saltedge.LoginSetupWorker do
+  use GenServer
+  import Ecto.Query
+  require Logger
+
+  def start_link(_opts \\ []) do
+    GenServer.start_link(__MODULE__, :ok, name: :login_setup_worker)
+  end
+
+  def handle_info({:setup, user_id, login_id}, state) do
+    login = fetch_login(user_id, login_id, 5)
+
+    ExMoney.Saltedge.Account.sync([login.saltedge_login_id])
+
+    account_ids = ExMoney.Account
+    |> where([a], a.saltedge_login_id == ^login.saltedge_login_id)
+    |> ExMoney.Repo.all
+    |> Enum.map(fn(account) -> GenServer.cast(:transactions_worker, {:fetch, account.saltedge_account_id}) end)
+
+    {:stop, :normal, state}
+  end
+
+  def handle_call(:stop, _from, state) do
+    {:stop, :normal, :ok, state}
+  end
+
+  defp fetch_login(user_id, login_id, attempts) do
+    ExMoney.Saltedge.Login.sync(user_id, login_id)
+
+    login = ExMoney.Login
+    |> where([l], l.saltedge_login_id == ^login_id)
+    |> limit([l], 1)
+    |> ExMoney.Repo.one
+
+    case login.status do
+      _ when attempts == 0 ->
+        Logger.error("LoginSetupWorker has been stopped because login #{login.id} is still not active")
+        GenServer.call(:login_setup_worker, :stop)
+      "active" -> login
+      "inactive" ->
+        :timer.sleep(3000)
+        fetch_login(user_id, login_id, attempts - 1)
+      "disabled" ->
+        Logger.error("Login #{login_id} is disabled.")
+        GenServer.call(:login_setup_worker, :stop)
+    end
+  end
+end

--- a/web/controllers/callbacks_controller.ex
+++ b/web/controllers/callbacks_controller.ex
@@ -17,12 +17,12 @@ defmodule CallbacksController do
 
     if user do
       changeset = Ecto.Model.build(user, :logins)
-      |> Login.success_callback_changeset(%{saltedge_login_id: login_id})
+      |> Login.success_callback_changeset(%{saltedge_login_id: login_id, user_id: user.id})
 
       if changeset.valid? do
         case Repo.insert(changeset) do
           {:ok, login} ->
-            spawn(fn -> ExMoney.Saltedge.Login.sync(user.id) end)
+            Process.send_after(:login_setup_worker, {:setup, user.id, login_id}, 5000)
 
             put_resp_content_type(conn, "application/json")
             |> send_resp(200, "ok")

--- a/web/models/login.ex
+++ b/web/models/login.ex
@@ -41,7 +41,7 @@ defmodule ExMoney.Login do
 
   def success_callback_changeset(model, params \\ :empty) do
     model
-    |> cast(params, ~w(saltedge_login_id), ~w())
+    |> cast(params, ~w(saltedge_login_id user_id), ~w())
   end
 
   def failure_callback_changeset(model, params \\ :empty) do


### PR DESCRIPTION
Once `success` callback from Saltedge is received, `LoginSetupWorker` is started. This worker tries to fetch logins(5 times with 3 seconds interval), then accounts and then transactions.
