### PR TITLE
Improve `TransactionsWorker`

### DIFF
--- a/lib/ex_money/saltedge/login_setup_worker.ex
+++ b/lib/ex_money/saltedge/login_setup_worker.ex
@@ -15,13 +15,45 @@ defmodule ExMoney.Saltedge.LoginSetupWorker do
     account_ids = ExMoney.Account
     |> where([a], a.saltedge_login_id == ^login.saltedge_login_id)
     |> ExMoney.Repo.all
-    |> Enum.map(fn(account) -> GenServer.cast(:transactions_worker, {:fetch, account.saltedge_account_id}) end)
+    |> Enum.map(fn(account) -> account.saltedge_account_id end)
+    |> start_transactions_worker
 
     {:stop, :normal, state}
   end
 
   def handle_call(:stop, _from, state) do
     {:stop, :normal, :ok, state}
+  end
+
+  defp start_transactions_worker([]) do
+    Logger.info("No accounts fetched, TransactionsWorker is not started")
+  end
+
+  defp start_transactions_worker(account_ids) do
+    pid = :erlang.whereis(:transactions_worker)
+
+    _start_transactions_worker(pid, account_ids)
+  end
+
+  defp _start_transactions_worker(:undefined, account_ids) do
+    [head | tail] = account_ids
+
+    Supervisor.start_child(
+      ExMoney.Supervisor,
+      Supervisor.Spec.worker(
+        ExMoney.Saltedge.TransactionsWorker,
+        [[saltedge_account_id: head]],
+        restart: :transient
+      )
+    )
+
+    Enum.each(tail, fn(account_id) ->
+      GenServer.cast(:transactions_worker, {:fetch, account_id})
+    end)
+  end
+
+  defp _start_transactions_worker(pid, _) do
+    Logger.info("TransactionsWorker was already started with pid #{pid}")
   end
 
   defp fetch_login(user_id, login_id, attempts) do

--- a/lib/ex_money/saltedge/transactions_worker.ex
+++ b/lib/ex_money/saltedge/transactions_worker.ex
@@ -8,7 +8,7 @@ defmodule ExMoney.Saltedge.TransactionsWorker do
   alias ExMoney.Repo
   alias ExMoney.Transaction
 
-  @interval 20 * 60 * 1000
+  @interval 29 * 60 * 1000
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: :transactions_worker)


### PR DESCRIPTION
Instead of starting `TransactionsWorker` worker on app start,
it should be started only once the app got accounts from Saltedge.