### PR TITLE
Better categories

### DIFF
--- a/lib/ex_money/saltedge/transactions_worker.ex
+++ b/lib/ex_money/saltedge/transactions_worker.ex
@@ -152,8 +152,7 @@ defmodule ExMoney.Saltedge.TransactionsWorker do
   defp find_or_create_category(name) do
     case Category.by_name(name) |> Repo.one do
       nil ->
-        humanized_name = String.replace(name, "_", " ") |> String.capitalize
-        changeset = Category.changeset(%Category{}, %{name: name, humanized_name: humanized_name})
+        changeset = Category.changeset(%Category{}, %{name: name})
         Repo.insert!(changeset)
 
       existing_category -> existing_category

--- a/web/controllers/mobile/account_controller.ex
+++ b/web/controllers/mobile/account_controller.ex
@@ -23,13 +23,19 @@ defmodule ExMoney.Mobile.AccountController do
 
     categories = Transaction.by_month_by_category(account_id, from, to)
     |> Repo.all
-    |> Enum.reduce([], fn({category, color, amount}, acc) ->
+    |> Enum.reduce(%{}, fn({category, amount}, acc) ->
       {float_amount, _} = Decimal.to_string(amount, :normal)
       |> Float.parse
 
       positive_float = float_amount * -1
 
-      [{category, color, positive_float} | acc]
+      Map.put(acc, category.id,
+        %{
+          humanized_name: category.humanized_name,
+          css_color: category.css_color,
+          amount: positive_float,
+          parent_id: category.parent_id
+        })
     end)
 
     current_month = current_month(parsed_date)

--- a/web/controllers/mobile/account_controller.ex
+++ b/web/controllers/mobile/account_controller.ex
@@ -21,7 +21,7 @@ defmodule ExMoney.Mobile.AccountController do
     month_transactions = Transaction.by_month(account_id, from, to)
     |> Repo.all
 
-    categories = Transaction.by_month_by_category(account_id, from, to)
+    categories = Transaction.group_by_month_by_category(account_id, from, to)
     |> Repo.all
     |> Enum.reduce(%{}, fn({category, amount}, acc) ->
       {float_amount, _} = Decimal.to_string(amount, :normal)
@@ -31,6 +31,7 @@ defmodule ExMoney.Mobile.AccountController do
 
       Map.put(acc, category.id,
         %{
+          id: category.id,
           humanized_name: category.humanized_name,
           css_color: category.css_color,
           amount: positive_float,

--- a/web/controllers/transaction_controller.ex
+++ b/web/controllers/transaction_controller.ex
@@ -24,9 +24,20 @@ defmodule ExMoney.TransactionController do
   end
 
   def new(conn, _params) do
-    changeset = Transaction.changeset(%Transaction{})
+    changeset = Transaction.changeset_custom(%Transaction{})
     accounts = Account.only_custom |> Repo.all
-    categories = Category.select_list |> Repo.all
+
+    categories_dict = Repo.all(Category)
+
+    categories = Enum.reduce(categories_dict, %{}, fn(category, acc) ->
+      if is_nil(category.parent_id) do
+        sub_categories = Enum.filter(categories_dict, fn(c) -> c.parent_id == category.id end)
+        |> Enum.map(fn(sub_category) -> {sub_category.humanized_name, sub_category.id} end)
+        Map.put(acc, {category.humanized_name, category.id}, sub_categories)
+      else
+        acc
+      end
+    end)
 
     render conn, :new,
       changeset: changeset,

--- a/web/models/category.ex
+++ b/web/models/category.ex
@@ -44,6 +44,12 @@ defmodule ExMoney.Category do
       where: c.id in ^(ids)
   end
 
+  def sub_categories_by_id(id) do
+    from c in Category,
+      where: c.parent_id == ^id,
+      select: c.id
+  end
+
   def select_list do
     from c in Category,
       select: {c.humanized_name, c.id},

--- a/web/models/transaction.ex
+++ b/web/models/transaction.ex
@@ -120,8 +120,8 @@ defmodule ExMoney.Transaction do
       where: tr.made_on >= ^from,
       where: tr.made_on <= ^to,
       where: tr.account_id == ^account_id,
-      group_by: [c.humanized_name, c.css_color],
-      select: {c.humanized_name, c.css_color, sum(tr.amount)},
+      group_by: [c.id],
+      select: {c, sum(tr.amount)},
       having: sum(tr.amount) < 0
   end
 

--- a/web/models/transaction.ex
+++ b/web/models/transaction.ex
@@ -102,6 +102,12 @@ defmodule ExMoney.Transaction do
       where: tr.account_id == ^account_id
   end
 
+  def by_month_by_category(account_id, from, to, category_ids) do
+    Transaction.by_month(account_id, from, to)
+    |> where([tr], tr.category_id in ^(category_ids))
+    |> preload([:transaction_info, :category])
+  end
+
   def expenses_by_month(account_id, from, to) do
     Transaction.by_month(account_id, from ,to)
     |> where([tr], tr.amount < 0)
@@ -114,7 +120,7 @@ defmodule ExMoney.Transaction do
     |> preload([:transaction_info, :category])
   end
 
-  def by_month_by_category(account_id, from, to) do
+  def group_by_month_by_category(account_id, from, to) do
     from tr in Transaction,
       join: c in assoc(tr, :category),
       where: tr.made_on >= ^from,

--- a/web/router.ex
+++ b/web/router.ex
@@ -48,6 +48,7 @@ defmodule ExMoney.Router do
       get "/user", UserController, :edit
       put "/user", UserController, :update
       resources "/accounts", AccountController
+      get "/categories/sync", CategoryController, :sync
       resources "/categories", CategoryController
       resources "/rules", RuleController
       resources "/logins", LoginController, only: [:index, :delete]

--- a/web/static/vendor/Framework7/css/framework7.ios.css
+++ b/web/static/vendor/Framework7/css/framework7.ios.css
@@ -5,7 +5,7 @@
  * iOS Theme
  *
  * 
- * Included modules: modals,swipeout,cards,smart-select,scroll-toolbars,fast-clicks,forms,notifications,calendar,searchbar,modals
+ * Included modules: modals,swipeout,cards,smart-select,scroll-toolbars,fast-clicks,forms,notifications,calendar,searchbar,modals,accordion,modals
  * 
  * http://www.idangero.us/framework7
  * 
@@ -15,7 +15,7 @@
  * 
  * Licensed under MIT
  * 
- * Released on: February 23, 2016
+ * Released on: March 8, 2016
  */
 html,
 body {
@@ -4930,6 +4930,79 @@ html:not(.watch-active-state) .searchbar.searchbar-active .searchbar-cancel:acti
 .navbar-fixed > .searchbar ~ .page-content,
 .navbar-through > .searchbar ~ .page-content {
   padding-top: 88px;
+}
+/* === Accordion === */
+.list-block .accordion-item-toggle {
+  cursor: pointer;
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+}
+.list-block .accordion-item-toggle .item-inner {
+  padding-right: 35px;
+  background: no-repeat -webkit-calc(100% - 15px) center;
+  background: no-repeat calc(100% - 15px) center;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D'0%200%2060%20120'%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%3E%3Cpath%20d%3D'm60%2061.5-38.25%2038.25-9.75-9.75%2029.25-28.5-29.25-28.5%209.75-9.75z'%20fill%3D'%23c7c7cc'%2F%3E%3C%2Fsvg%3E");
+  background-size: 10px 20px;
+}
+html:not(.watch-active-state) .list-block .accordion-item-toggle:active,
+.list-block .accordion-item-toggle.active-state {
+  -webkit-transition-duration: 0ms;
+  transition-duration: 0ms;
+  background-color: #d9d9d9;
+}
+html:not(.watch-active-state) .list-block .accordion-item-toggle:active > .item-inner:after,
+.list-block .accordion-item-toggle.active-state > .item-inner:after {
+  background-color: transparent;
+}
+.list-block .accordion-item-toggle .item-inner,
+.list-block .accordion-item > .item-link .item-inner {
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+  -webkit-transition-property: background-color;
+  transition-property: background-color;
+}
+.list-block .accordion-item-toggle .item-inner:after,
+.list-block .accordion-item > .item-link .item-inner:after {
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+}
+.list-block:not(.media-list) .accordion-item-expanded:not(.media-item) .accordion-item-toggle .item-inner,
+.list-block:not(.media-list) .accordion-item-expanded:not(.media-item) > .item-link .item-inner,
+.list-block.media-list .accordion-item-expanded .accordion-item-toggle .item-title-row,
+.list-block.media-list .accordion-item-expanded > .item-link .item-title-row,
+.list-block .accordion-item-expanded.media-item .accordion-item-toggle .item-title-row,
+.list-block .accordion-item-expanded.media-item > .item-link .item-title-row {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D'0%200%2060%20120'%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%3E%3Cpath%20d%3D'm60%2061.5-38.25%2038.25-9.75-9.75%2029.25-28.5-29.25-28.5%209.75-9.75z'%20transform%3D'translate(115%2C%2030)%20rotate(90)'%20fill%3D'%23c7c7cc'%2F%3E%3C%2Fsvg%3E");
+  background-size: 20px 20px;
+}
+.list-block .accordion-item-expanded .accordion-item-toggle .item-inner:after,
+.list-block .accordion-item-expanded > .item-link .item-inner:after {
+  background-color: transparent;
+}
+.list-block .accordion-item .content-block,
+.list-block .accordion-item .list-block {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.list-block .accordion-item ul {
+  padding-left: 0;
+}
+.accordion-item-content {
+  position: relative;
+  overflow: hidden;
+  height: 0;
+  font-size: 14px;
+  -webkit-transition-duration: 300ms;
+  transition-duration: 300ms;
+  -webkit-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
+}
+.accordion-item-expanded > .accordion-item-content {
+  height: auto;
+}
+html.android-4 .accordion-item-content {
+  -webkit-transform: none;
+  transform: none;
 }
 /* === Login screen === */
 .login-screen-content {

--- a/web/static/vendor/Framework7/js/framework7.js
+++ b/web/static/vendor/Framework7/js/framework7.js
@@ -3,7 +3,7 @@
  * Full Featured Mobile HTML Framework For Building iOS & Android Apps
  * 
  * 
- * Included modules: modals,swipeout,cards,smart-select,scroll-toolbars,fast-clicks,forms,notifications,calendar,searchbar,modals
+ * Included modules: modals,swipeout,cards,smart-select,scroll-toolbars,fast-clicks,forms,notifications,calendar,searchbar,modals,accordion,modals
  * 
  * http://www.idangero.us/framework7
  * 
@@ -13,7 +13,7 @@
  * 
  * Licensed under MIT
  * 
- * Released on: February 23, 2016
+ * Released on: March 8, 2016
  */
 (function () {
 
@@ -7594,6 +7594,67 @@
             else if (container.hasClass('navbar-inner')) {
                 container.once('navbarBeforeRemove', onBeforeRemove);
             }
+        };
+
+        /*===============================================================================
+        ************   Accordion   ************
+        ===============================================================================*/
+        app.accordionToggle = function (item) {
+            item = $(item);
+            if (item.length === 0) return;
+            if (item.hasClass('accordion-item-expanded')) app.accordionClose(item);
+            else app.accordionOpen(item);
+        };
+        app.accordionOpen = function (item) {
+            item = $(item);
+            var list = item.parents('.accordion-list').eq(0);
+            var content = item.children('.accordion-item-content');
+            if (content.length === 0) content = item.find('.accordion-item-content');
+            var expandedItem = list.length > 0 && item.parent().children('.accordion-item-expanded');
+            if (expandedItem.length > 0) {
+                app.accordionClose(expandedItem);
+            }
+            content.css('height', content[0].scrollHeight + 'px').transitionEnd(function () {
+                if (item.hasClass('accordion-item-expanded')) {
+                    content.transition(0);
+                    content.css('height', 'auto');
+                    var clientLeft = content[0].clientLeft;
+                    content.transition('');
+                    item.trigger('opened');
+                }
+                else {
+                    content.css('height', '');
+                    item.trigger('closed');
+                }
+            });
+            item.trigger('open');
+            item.addClass('accordion-item-expanded');
+        };
+        app.accordionClose = function (item) {
+            item = $(item);
+            var content = item.children('.accordion-item-content');
+            if (content.length === 0) content = item.find('.accordion-item-content');
+            item.removeClass('accordion-item-expanded');
+            content.transition(0);
+            content.css('height', content[0].scrollHeight + 'px');
+            // Relayout
+            var clientLeft = content[0].clientLeft;
+            // Close
+            content.transition('');
+            content.css('height', '').transitionEnd(function () {
+                if (item.hasClass('accordion-item-expanded')) {
+                    content.transition(0);
+                    content.css('height', 'auto');
+                    var clientLeft = content[0].clientLeft;
+                    content.transition('');
+                    item.trigger('opened');
+                }
+                else {
+                    content.css('height', '');
+                    item.trigger('closed');
+                }
+            });
+            item.trigger('close');
         };
 
         /*===========================

--- a/web/static/vendor/Framework7_custom/css/app.css
+++ b/web/static/vendor/Framework7_custom/css/app.css
@@ -8,24 +8,23 @@
 
 .horizontal .progress-bar {
   float: left;
-  height: 45px;
   width: 100%;
 }
 
 .horizontal .progress-track {
   position: relative;
   width: 100%;
-  height: 20px;
+  height: 30px;
   background: #ebebeb;
 }
 
 .horizontal .progress-fill {
   position: relative;
-  height: 20px;
+  height: 30px;
   width: 50%;
   text-align: left;
-  font-size: 14px;
-  line-height: 20px;
+  font-size: 16px;
+  line-height: 30px;
 }
 
 .reduced-margin {

--- a/web/static/vendor/Framework7_custom/css/app.css
+++ b/web/static/vendor/Framework7_custom/css/app.css
@@ -48,3 +48,7 @@
 .blurred {
   -webkit-filter: blur(5px);
 }
+
+-moz-user-select: none;
+-webkit-user-select: none;
+user-select: none;

--- a/web/static/vendor/Framework7_custom/js/app.js
+++ b/web/static/vendor/Framework7_custom/js/app.js
@@ -3,6 +3,8 @@ var $$ = Dom7;
 var exMoney = new Framework7({
   modalTitle: 'ExMoney',
   scrollTopOnNavbarClick: true,
+  tapHold: true,
+  tapHoldDelay: 500,
 
   onAjaxStart: function (xhr) {
     exMoney.showIndicator();
@@ -118,6 +120,16 @@ function adjustSelectedCategory() {
   var category = $$('a.smart-select div.item-content div.item-inner div.item-after');
   category.text(category.text().replace(/\u21b3/g, ""));
 };
+
+exMoney.onPageInit('account-screen', function (page) {
+  $$('a.category-bar').on('taphold', function () {
+    var category_id = $$(this).data("category-id");
+    var date = $$("#current_date").data("current-date");
+    var account_id = $$("#account_id").data("account-id");
+
+    mainView.router.load({ url: '/m/transactions?category_id='+category_id+'&date='+date+'&account_id='+account_id });
+  });
+});
 
 exMoney.onPageInit('edit-transaction-screen', function (page) {
   adjustSelectedCategory();

--- a/web/static/vendor/Framework7_custom/js/app.js
+++ b/web/static/vendor/Framework7_custom/js/app.js
@@ -114,7 +114,18 @@ var exMoney = new Framework7({
 
 var mainView = exMoney.addView('.view-main');
 
-exMoney.onPageBeforeInit('edit-transaction-screen', function (page) {
+function adjustSelectedCategory() {
+  var category = $$('a.smart-select div.item-content div.item-inner div.item-after');
+  category.text(category.text().replace(/\u21b3/g, ""));
+};
+
+exMoney.onPageInit('edit-transaction-screen', function (page) {
+  adjustSelectedCategory();
+
+  $$('#transaction_category_id').on('change', function(e) {
+    setTimeout(function() { adjustSelectedCategory(); }, 100);
+  });
+
   $$('form.ajax-submit').on('submitted', function (e) {
     var xhr = e.detail.xhr;
 

--- a/web/static/vendor/Framework7_custom/js/app.js
+++ b/web/static/vendor/Framework7_custom/js/app.js
@@ -117,7 +117,7 @@ var exMoney = new Framework7({
 var mainView = exMoney.addView('.view-main');
 
 function adjustSelectedCategory() {
-  var category = $$('a.smart-select div.item-content div.item-inner div.item-after');
+  var category = $$('a.smart-category-select div.item-content div.item-inner div.item-after');
   category.text(category.text().replace(/\u21b3/g, ""));
 };
 
@@ -153,7 +153,13 @@ exMoney.onPageInit('edit-transaction-screen', function (page) {
   });
 });
 
-exMoney.onPageBeforeInit('new-transaction-screen', function (page) {
+exMoney.onPageInit('new-transaction-screen', function (page) {
+  adjustSelectedCategory();
+
+  $$('#transaction_category_id').on('change', function(e) {
+    setTimeout(function() { adjustSelectedCategory(); }, 100);
+  });
+
   var calculator = exMoney.keypad({
     input: '#new-transaction-amount',
     toolbar: false,

--- a/web/templates/mobile/account/show.html.eex
+++ b/web/templates/mobile/account/show.html.eex
@@ -72,12 +72,27 @@
             <div class="row">
               <div class="container horizontal flat">
                 <h3>Top Expenses</h3>
-                <%= for {category, color, width, amount} <- categories_chart_data(@categories) do %>
-                  <div class="progress-bar horizontal">
-                    <div class="progress-track">
-                      <div class="progress-fill" style="width:<%= width %>; background: <%= color %>">
-                        <span><%= Float.to_string(amount, compact: true, decimals: 0) %>&nbsp;<%= raw category %></span>
+                <%= for {{category, color, width, amount}, sub_categories} <- categories_chart_data(@categories) do %>
+                  <div class="progress-bar horizontal accordion-item">
+                    <a href="#" class="item-content item-link" style="color: black">
+                      <div class="progress-track">
+                        <div class="progress-fill" style="width:<%= width %>; background: <%= color %>">
+                          <span><%= Float.to_string(amount, compact: true, decimals: 1) %>&nbsp;<%= raw category %></span>
+                        </div>
                       </div>
+                    </a>
+                    <div class="accordion-item-content" style="margin-left: 20px">
+                      <%= if Enum.count(sub_categories) > 0 do %>
+                        <div class="progress-bar horizontal">
+                          <%= for {category, _color, width, amount} <- sub_categories do %>
+                            <div class="progress-track" style="margin-top: 10px">
+                              <div class="progress-fill" style="width:<%= width %>; background: #b3b3b3">
+                                <span><%= Float.to_string(amount, compact: true, decimals: 1) %>&nbsp;<%= raw category %></span>
+                              </div>
+                            </div>
+                          <% end %>
+                        </div>
+                      <% end %>
                     </div>
                   </div>
                 <% end %>

--- a/web/templates/mobile/account/show.html.eex
+++ b/web/templates/mobile/account/show.html.eex
@@ -9,7 +9,7 @@
                 <i class="icon icon-back"></i>&nbsp; Home
               </a>
             </div>
-            <div class="center"><%= @account.name %></div>
+            <div class="center" id="account_id" data-account-id="<%= @account.id %>"><%= @account.name %></div>
             <%= if @account.login.interactive == true do %>
               <div class="right">
                 <%= link "Refresh", to: mobile_account_path(@conn, :refresh, @account), data: [force: "true"] %>
@@ -25,7 +25,7 @@
                   &#8592; <%= @previous_month.label %>
                 </a>
               </div>
-              <div class="col-33">
+              <div class="col-33" id="current_date" data-current-date="<%= @current_month.date %>">
                 <%= @current_month.label %>
               </div>
               <div class="col-33" align="right">
@@ -72,9 +72,9 @@
             <div class="row">
               <div class="container horizontal flat">
                 <h3>Top Expenses</h3>
-                <%= for {{category, color, width, amount}, sub_categories} <- categories_chart_data(@categories) do %>
+                <%= for {{id, category, color, width, amount}, sub_categories} <- categories_chart_data(@categories) do %>
                   <div class="progress-bar horizontal accordion-item">
-                    <a href="#" class="item-content item-link" style="color: black">
+                    <a href="#" class="category-bar item-content item-link" style="color: black" data-category-id="<%= id %>">
                       <div class="progress-track">
                         <div class="progress-fill" style="width:<%= width %>; background: <%= color %>">
                           <span><%= Float.to_string(amount, compact: true, decimals: 1) %>&nbsp;<%= raw category %></span>
@@ -84,12 +84,14 @@
                     <div class="accordion-item-content" style="margin-left: 20px">
                       <%= if Enum.count(sub_categories) > 0 do %>
                         <div class="progress-bar horizontal">
-                          <%= for {category, _color, width, amount} <- sub_categories do %>
-                            <div class="progress-track" style="margin-top: 10px">
-                              <div class="progress-fill" style="width:<%= width %>; background: #b3b3b3">
-                                <span><%= Float.to_string(amount, compact: true, decimals: 1) %>&nbsp;<%= raw category %></span>
+                          <%= for {id, category, _color, width, amount} <- sub_categories do %>
+                            <a href="#" class="category-bar" style="color: black" data-category-id="<%= id %>">
+                              <div class="progress-track" style="margin-top: 10px">
+                                <div class="progress-fill" style="width:<%= width %>; background: #b3b3b3">
+                                  <span><%= Float.to_string(amount, compact: true, decimals: 1) %>&nbsp;<%= raw category %></span>
+                                </div>
                               </div>
-                            </div>
+                            </a>
                           <% end %>
                         </div>
                       <% end %>

--- a/web/templates/mobile/transaction/categories_list.html.eex
+++ b/web/templates/mobile/transaction/categories_list.html.eex
@@ -1,0 +1,14 @@
+<select class="form-control" id="transaction_category_id" name="transaction[category_id]">
+  <%= for {{name, id}, sub_categories} <- @categories do %>
+    <option <%= if id == @selected, do: "selected=selected" %> value="<%= id %>">
+      <%= name %>
+    </option>
+
+    <%= for {name, id} <- sub_categories do %>
+      <option <%= if id == @selected, do: "selected=selected" %> value="<%= id %>">
+        &#8627;&nbsp;<%= name %>
+      </option>
+    <% end %>
+  <% end %>
+</select>
+

--- a/web/templates/mobile/transaction/edit.html.eex
+++ b/web/templates/mobile/transaction/edit.html.eex
@@ -15,16 +15,8 @@
         <%= form_for @changeset, mobile_transaction_path(@conn, :update, @transaction), [method: :put, class: "ajax-submit"], fn f -> %>
           <ul>
             <li>
-              <a href="#" class="item-link smart-select" data-back-on-select="true" data-open-in="popup" data-searchbar="true" data-page-title="Choose Category">
-                <select class="form-control" id="transaction_category_id" name="transaction[category_id]">
-                  <%= for {{name, id}, sub_categories} <- @categories do %>
-                    <option <%= if id == @transaction.category_id, do: "selected=selected" %> value="<%= id %>"><%= name %></option>
-                    <%= for {name, id} <- sub_categories do %>
-                      <option <%= if id == @transaction.category_id, do: "selected=selected" %> value="<%= id %>">&#8627;&nbsp;<%= name %></option>
-                    <% end %>
-                  <% end %>
-                </select>
-
+              <a href="#" class="item-link smart-select smart-category-select" data-back-on-select="true" data-open-in="popup" data-searchbar="true" data-page-title="Choose Category">
+                <%= render "categories_list.html", categories: @categories, selected: @transaction.category_id %>
                 <div class="item-content">
                   <div class="item-inner">
                     <div class="item-title">Category</div>

--- a/web/templates/mobile/transaction/edit.html.eex
+++ b/web/templates/mobile/transaction/edit.html.eex
@@ -16,7 +16,15 @@
           <ul>
             <li>
               <a href="#" class="item-link smart-select" data-back-on-select="true" data-open-in="popup" data-searchbar="true" data-page-title="Choose Category">
-                <%= select(f, :category_id, @categories) %>
+                <select class="form-control" id="transaction_category_id" name="transaction[category_id]">
+                  <%= for {{name, id}, sub_categories} <- @categories do %>
+                    <option <%= if id == @transaction.category_id, do: "selected=selected" %> value="<%= id %>"><%= name %></option>
+                    <%= for {name, id} <- sub_categories do %>
+                      <option <%= if id == @transaction.category_id, do: "selected=selected" %> value="<%= id %>">&#8627;&nbsp;<%= name %></option>
+                    <% end %>
+                  <% end %>
+                </select>
+
                 <div class="item-content">
                   <div class="item-inner">
                     <div class="item-title">Category</div>

--- a/web/templates/mobile/transaction/index.html.eex
+++ b/web/templates/mobile/transaction/index.html.eex
@@ -1,0 +1,46 @@
+<div class="pages">
+  <div class="page navbar-fixed" data-page="transactions-screen">
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="left">
+          <a href="#" class="link back">
+            <i class="icon icon-back"></i>&nbsp; Back
+          </a>
+        </div>
+        <div class="center"><%= @category %></div>
+      </div>
+    </div>
+    <div class="page-content hide-navbar-on-scroll">
+      <div class="list-block reduced-margin media-list">
+      <ul>
+        <%= for {date, transactions} <- @transactions do %>
+          <li class="item-divider">
+            <div class="row">
+              <div class="col-50"><%= date %></div>
+              <div class="col-50" align="right"><%= balance(transactions) %> <%= @currency_label %></div>
+            </div>
+          </li>
+          <%= for transaction <- transactions do %>
+            <li class="item-content">
+              <div class="item-inner">
+                <div class="item-title-row">
+                  <div class="item-title"><%= description(transaction) %></div>
+                </div>
+                <div class="item-subtitle">
+                  <div class="row">
+                    <div class="col-50">
+                      <%= transaction.category.humanized_name %>
+                    </div>
+                    <div class="col-50" align="right">
+                      <%= transaction.amount %> <%= @currency_label %>
+                    </div>
+                </div>
+              </div>
+            </li>
+          <% end %>
+        <% end %>
+      </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/web/templates/mobile/transaction/new.html.eex
+++ b/web/templates/mobile/transaction/new.html.eex
@@ -48,8 +48,8 @@
               </a>
             </li>
             <li>
-              <a href="#" class="item-link smart-select" data-back-on-select="true" data-open-in="popup" data-searchbar="true" data-page-title="Choose Category">
-                <%= select(f, :category_id, @categories) %>
+              <a href="#" class="item-link smart-select smart-category-select" data-back-on-select="true" data-open-in="popup" data-searchbar="true" data-page-title="Choose Category">
+                <%= render "categories_list.html", categories: @categories, selected: nil %>
                 <div class="item-content">
                   <div class="item-inner">
                     <div class="item-title">Category</div>

--- a/web/templates/settings/category/index.html.eex
+++ b/web/templates/settings/category/index.html.eex
@@ -2,26 +2,27 @@
   <%= render ExMoney.SharedView, "settings_navbar.html", conn: @conn, navigation: @navigation %>
 
   <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
-    <h1 class="page-header">Categories [<%= link "New", to: settings_category_path(@conn, :new) %>]</h1>
+    <h2 class="sub-header">Categories
+      [<%= link "New", to: settings_category_path(@conn, :new) %>]
+      [<%= link "Sync with Saltedge", to: settings_category_path(@conn, :sync) %>]
+    </h1>
 
     <div class="table-responsive">
       <table class="table table-striped">
         <thead>
           <tr>
-            <th>Id</th>
             <th>Name</th>
             <th>Humanized name</th>
-            <th>Parent Id</th>
+            <th>Parent Category</th>
             <th>Actions</th>
           </tr>
         </thead>
         <tbody>
           <%= for category <- @categories do %>
             <tr>
-              <td><%= category.id %></td>
               <td><%= category.name %></td>
               <td><%= category.humanized_name %></td>
-              <td><%= category.parent_id %></td>
+              <td><%= parent_category(category.parent) %></td>
               <td>
                 <%= link "Edit", to: settings_category_path(@conn, :edit, category), class: "btn btn-default btn-xs" %>
                 <%= link "Delete", to: settings_category_path(@conn, :delete, category), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>

--- a/web/templates/settings/login/index.html.eex
+++ b/web/templates/settings/login/index.html.eex
@@ -2,31 +2,36 @@
   <%= render ExMoney.SharedView, "settings_navbar.html", conn: @conn, navigation: @navigation %>
 
   <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
-  <h2 class="sub-header">Logins(<%= link "New", to: saltedge_login_path(@conn, :new) %>, <%= link "Sync", to: saltedge_login_path(@conn, :sync) %>)</h2>
-  <div class="table-responsive">
-    <table class="table table-striped">
-      <thead>
-        <tr>
-          <th>Id</th>
-          <th>Saltedge id</th>
-          <th>Name</th>
-          <th>Status</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= for login <- @logins do %>
+    <h2 class="sub-header">
+      Logins
+      [<%= link "New", to: saltedge_login_path(@conn, :new) %>]
+      [<%= link "Sync", to: saltedge_login_path(@conn, :sync) %>]
+    </h2>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead>
           <tr>
-            <td><%= login.id %></td>
-            <td><%= login.saltedge_login_id %></td>
-            <td><%= login.provider_name %></td>
-            <td><%= login.status %></td>
-            <td>
-              <%= link "Delete", to: settings_login_path(@conn, :delete, login), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
-            </td>
+            <th>Id</th>
+            <th>Saltedge id</th>
+            <th>Name</th>
+            <th>Status</th>
+            <th>Actions</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <%= for login <- @logins do %>
+            <tr>
+              <td><%= login.id %></td>
+              <td><%= login.saltedge_login_id %></td>
+              <td><%= login.provider_name %></td>
+              <td><%= login.status %></td>
+              <td>
+                <%= link "Delete", to: settings_login_path(@conn, :delete, login), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/web/templates/settings/rule/accounts_list.html.eex
+++ b/web/templates/settings/rule/accounts_list.html.eex
@@ -1,0 +1,1 @@
+<%= select @f, :target_id, @target, class: "form-control" %>

--- a/web/templates/settings/rule/categories_list.html.eex
+++ b/web/templates/settings/rule/categories_list.html.eex
@@ -1,0 +1,9 @@
+<select class="form-control" id="rule_target_id" name="rule[target_id]">
+  <option value="">Choose category</option>
+  <%= for {{name, id}, sub_categories} <- @target do %>
+    <option value="<%= id %>"><%= name %></option>
+    <%= for {name, id} <- sub_categories do %>
+      <option value="<%= id %>">&nbsp;&nbsp;&nbsp;<%= name %></option>
+    <% end %>
+  <% end %>
+</select>

--- a/web/templates/settings/rule/form.html.eex
+++ b/web/templates/settings/rule/form.html.eex
@@ -27,7 +27,11 @@
 
   <div class="form-group">
     <%= label f, :rule_target_id, class: "control-label" %>
-    <%= select f, :target_id, @target, class: "form-control" %>
+    <%= if @conn.params["type"] == "assign_category" do %>
+      <%= render "categories_list.html", target: @target %>
+    <% else %>
+      <%= render "accounts_list.html", target: @target, f: f %>
+    <% end %>
   </div>
 
   <div class="checkbox">

--- a/web/templates/transaction/form.html.eex
+++ b/web/templates/transaction/form.html.eex
@@ -21,8 +21,25 @@
   </div>
 
   <div class="form-group">
+    <label class="radio-inline">
+      <%= radio_button(f, :type, "expense", checked: "checked") %> Expense
+    </label>
+    <label class="radio-inline">
+      <%= radio_button(f, :type, "income") %> Income
+    </label>
+  </div>
+
+  <div class="form-group">
     <label for="transaction_category_id">Category</label>
-    <%= select(f, :category_id, @categories, default: "29") %>
+    <select class="form-control" id="transaction_category_id" name="transaction[category_id]">
+      <option value="">Choose category</option>
+      <%= for {{name, id}, sub_categories} <- @categories do %>
+        <option value="<%= id %>"><%= name %></option>
+        <%= for {name, id} <- sub_categories do %>
+          <option value="<%= id %>">&nbsp;&nbsp;&nbsp;<%= name %></option>
+        <% end %>
+      <% end %>
+    </select>
   </div>
 
   <div class="form-group">

--- a/web/views/mobile/account_view.ex
+++ b/web/views/mobile/account_view.ex
@@ -3,7 +3,7 @@ defmodule ExMoney.Mobile.AccountView do
 
   alias ExMoney.{Category, Repo}
 
-  def categories_chart_data([]), do: []
+  def categories_chart_data(%{}), do: []
 
   # FIXME Oh my, that's got complicated.
   # I hope there is a better way to generate data for the chart.

--- a/web/views/mobile/account_view.ex
+++ b/web/views/mobile/account_view.ex
@@ -71,8 +71,8 @@ defmodule ExMoney.Mobile.AccountView do
         end
       end)
       |> Enum.sort(fn(
-        {_cat_1, _color_1, _width_1, amount_1},
-        {_cat_2, _color_2, _width_2, amount_2}) ->
+        {_id_1, _cat_1, _color_1, _width_1, amount_1},
+        {_id_2, _cat_2, _color_2, _width_2, amount_2}) ->
           amount_1 > amount_2
       end)
 
@@ -85,8 +85,8 @@ defmodule ExMoney.Mobile.AccountView do
       end
     end)
     |> Enum.sort(fn(
-      {{_cat_1, _color_1, _width_1, amount_1}, _sub_categories_1},
-      {{_cat_2, _color_2, _width_2, amount_2}, _sub_categories_2}) ->
+      {{_id_1, _cat_1, _color_1, _width_1, amount_1}, _sub_categories_1},
+      {{_id_2, _cat_2, _color_2, _width_2, amount_2}, _sub_categories_2}) ->
         amount_1 > amount_2
     end)
   end
@@ -99,8 +99,8 @@ defmodule ExMoney.Mobile.AccountView do
     if percent == "0" do
       nil
     else
-      html_category = String.replace(category.humanized_name, " ", "&nbsp;")
-      {html_category, category.css_color, "#{percent}%", amount}
+      html_name = String.replace(category.humanized_name, " ", "&nbsp;")
+      {category.id, html_name, category.css_color, "#{percent}%", amount}
     end
   end
 

--- a/web/views/mobile/account_view.ex
+++ b/web/views/mobile/account_view.ex
@@ -1,29 +1,107 @@
 defmodule ExMoney.Mobile.AccountView do
   use ExMoney.Web, :view
 
+  alias ExMoney.{Category, Repo}
+
   def categories_chart_data([]), do: []
 
+  # FIXME Oh my, that's got complicated.
+  # I hope there is a better way to generate data for the chart.
   def categories_chart_data(categories) do
-    {_category, _color, max} = Enum.max_by(categories, fn({_category, _color, amount}) -> amount end)
+    parent_categories = Enum.map(categories, fn({_id, category}) -> category.parent_id end)
+    |> Enum.reject(&(is_nil(&1)))
+    |> Category.by_ids
+    |> Repo.all
+    |> Enum.reduce(%{}, fn(category, acc) ->
+      case Map.has_key?(acc, category.id) do
+        true -> acc
+        false -> Map.put(acc, category.id, category)
+      end
+    end)
 
-    Enum.reduce(categories, [], fn({category, color, amount}, acc) ->
-      percent = (amount * 100) / max
-      |> Float.round(0)
-      |> Float.to_string(compact: true, decimals: 0)
-
-      if percent == "0" do
-        acc
+    categories_tree = Enum.reduce(categories, %{}, fn({id, category}, acc) ->
+      if is_nil(category.parent_id) do
+        case Map.has_key?(acc, id) do
+          false -> Map.put(acc, id, [])
+          true -> acc
+        end
       else
-        html_category = String.replace(category, " ", "&nbsp;")
-        [{html_category, color, "#{percent}%", amount} | acc]
+        case Map.has_key?(acc, category.parent_id) do
+          false -> Map.put(acc, category.parent_id, [id])
+          true ->
+            sub_categories = Map.get(acc, category.parent_id, [])
+            Map.put(acc, category.parent_id, [id | sub_categories])
+        end
+      end
+    end)
+
+    max_amount = Enum.reduce(categories_tree, [], fn({id, sub_category_ids}, acc) ->
+      case sub_category_ids do
+        [] ->
+          category = parent_categories[id] || categories[id]
+          [category.amount | acc]
+        _ ->
+          sub_amount = Enum.reduce(sub_category_ids, 0, fn(sub_category_id, acc) ->
+            acc + categories[sub_category_id].amount
+          end)
+          [sub_amount | acc]
+      end
+    end) |> Enum.max
+
+
+    Enum.reduce(categories_tree, [], fn({id, sub_category_ids}, acc) ->
+      category = parent_categories[id] || categories[id]
+
+      amount = case sub_category_ids do
+        [] -> category.amount
+        _ ->
+          Enum.reduce(sub_category_ids, 0, fn(sub_category_id, acc) ->
+            acc + categories[sub_category_id].amount
+          end)
       end
 
+      sub_categories = Enum.reduce(sub_category_ids, [], fn(sub_category_id, acc) ->
+        sub_category = categories[sub_category_id]
+        sub_category = add_width(sub_category, sub_category.amount, amount)
+
+        if sub_category do
+          [sub_category | acc]
+        else
+          acc
+        end
+      end)
+      |> Enum.sort(fn(
+        {_cat_1, _color_1, _width_1, amount_1},
+        {_cat_2, _color_2, _width_2, amount_2}) ->
+          amount_1 > amount_2
+      end)
+
+      category = add_width(category, amount, max_amount)
+
+      if category do
+        [{category, sub_categories} | acc]
+      else
+        acc
+      end
     end)
     |> Enum.sort(fn(
-      {_cat_1, _color_1, _width_1, amount_1},
-      {_cat_2, _color_2, _width_2, amount_2}) ->
+      {{_cat_1, _color_1, _width_1, amount_1}, _sub_categories_1},
+      {{_cat_2, _color_2, _width_2, amount_2}, _sub_categories_2}) ->
         amount_1 > amount_2
     end)
+  end
+
+  defp add_width(category, amount, max_amount) do
+    percent = (amount * 100) / max_amount
+    |> Float.round(0)
+    |> Float.to_string(compact: true, decimals: 0)
+
+    if percent == "0" do
+      nil
+    else
+      html_category = String.replace(category.humanized_name, " ", "&nbsp;")
+      {html_category, category.css_color, "#{percent}%", amount}
+    end
   end
 
   def balance(transactions) do

--- a/web/views/mobile/account_view.ex
+++ b/web/views/mobile/account_view.ex
@@ -3,7 +3,9 @@ defmodule ExMoney.Mobile.AccountView do
 
   alias ExMoney.{Category, Repo}
 
-  def categories_chart_data(%{}), do: []
+  def categories_chart_data(categories) when map_size(categories) == 0 do
+    []
+  end
 
   # FIXME Oh my, that's got complicated.
   # I hope there is a better way to generate data for the chart.

--- a/web/views/settings/category_view.ex
+++ b/web/views/settings/category_view.ex
@@ -1,3 +1,6 @@
 defmodule ExMoney.Settings.CategoryView do
   use ExMoney.Web, :view
+
+  def parent_category(nil), do: ""
+  def parent_category(parent), do: parent.humanized_name
 end


### PR DESCRIPTION
Instead of creating categories one-by-one upon creating transactions from Saltedge, now ExMoney can fetch all categories from Saltedge keeping their hierarchy and display sub categories on account view nicely.

Before
<img width="432" alt="screen shot 2016-03-08 at 22 31 57" src="https://cloud.githubusercontent.com/assets/1541059/13617357/a1bb1556-e57e-11e5-92b4-abeed24a0caf.png">

After
<img width="432" alt="screen shot 2016-03-08 at 22 31 33" src="https://cloud.githubusercontent.com/assets/1541059/13617359/a7e9d6ec-e57e-11e5-8306-53f88049413f.png">

