### PR TITLE
Fix interactive password request

### DIFF
--- a/web/channels/interactive_channel.ex
+++ b/web/channels/interactive_channel.ex
@@ -16,8 +16,8 @@
     {:ok, socket}
   end
 
-  def handle_info({:interactive, _html, _fields}, socket) do
-    push socket, "otp", %{}
+  def handle_info({:interactive, _html, fields}, socket) do
+    push socket, "otp", %{field: List.first(fields)}
 
     {:noreply, socket}
   end
@@ -46,9 +46,9 @@
     {:reply, :ok, socket}
   end
 
-  def handle_in("otp", %{"otp" => otp, "login_id" => login_id}, socket) do
+  def handle_in("otp", %{"otp" => otp, "login_id" => login_id, "field" => field}, socket) do
     body = """
-      { "data": { "fetch_type": "recent", "credentials": { "otp": "#{otp}" }}}
+      { "data": { "fetch_type": "recent", "credentials": { "#{field}": "#{otp}" }}}
     """
 
     ExMoney.Saltedge.Client.request(:put, "logins/#{login_id}/interactive", body)

--- a/web/static/js/socket.js
+++ b/web/static/js/socket.js
@@ -84,7 +84,7 @@ exMoney.onPageInit('account-refresh-screen', function (page) {
     localStorage.setItem("interactive", JSON.stringify(interactive));
     exMoney.prompt('Please enter OTP', 'One Time Password',
       function(value) {
-        channel.push("otp", {otp: value, login_id: login_id})
+        channel.push("otp", {otp: value, login_id: login_id, field: msg.field})
         localStorage.setItem("interactive", JSON.stringify({status: false}))
       },
       function(value) {


### PR DESCRIPTION
Instead of sending interactive password as `otp` param it should be sent as param name from `interactive_fields_names` param in an interactive callback.