### PR TITLE
Fix HOME_URL var access

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,5 +1,5 @@
 erlang_version=18.3
 elixir_version=1.3.2
 always_rebuild=false
-config_vars_to_export=(DATABASE_URL)
+config_vars_to_export=(DATABASE_URL, HOME_URL)
 runtime_path=/app


### PR DESCRIPTION
When I tried to follow [instructions](https://github.com/gaynetdinov/ex_money/wiki/Heroku) to deploy on Heroku, I kept getting a redirect to "https://localhost" instead of any site page. In build log there was this warning:

```
remote:        Will export the following config vars:
remote:        * Config vars DATABASE_URL
remote:        * MIX_ENV=prod
...
remote: -----> Copying hex from /app/.mix/archives/hex-0.13.2
remote: -----> Compiling
remote: Compiling 75 files (.ex)
remote: warning: you have enabled :force_ssl but your host is currently set to localhost.
remote: Please configure your endpoint url host properly:
remote:
remote:     config ExMoney.Endpoint, url: [host: "YOURHOST.com"]
remote:
```

So I updated config to export HOME_URL var as well, and this worked.
Am I doing something wrong?
