### PR TITLE
[WIP] Introduce budget

### DIFF
--- a/lib/ex_money/date_helper.ex
+++ b/lib/ex_money/date_helper.ex
@@ -1,0 +1,54 @@
+defmodule ExMoney.DateHelper do
+  def today do
+    {today, _} = :calendar.local_time()
+    today
+  end
+
+  def parse_date(month) when month == "" or is_nil(month) do
+    Timex.Date.local
+  end
+
+  def parse_date(month) do
+    {:ok, date} = Timex.DateFormat.parse(month, "{YYYY}-{0M}")
+    date
+  end
+
+  def first_day_of_month(date) do
+    Timex.Date.from({{date.year, date.month, 0}, {0, 0, 0}})
+    |> Timex.DateFormat.format("%Y-%m-%d", :strftime)
+    |> elem(1)
+  end
+
+  def last_day_of_month(date) do
+    days_in_month = Timex.Date.days_in_month(date)
+
+    Timex.Date.from({{date.year, date.month, days_in_month}, {23, 59, 59}})
+    |> Timex.DateFormat.format("%Y-%m-%d", :strftime)
+    |> elem(1)
+  end
+
+  def current_month(date) do
+    {:ok, current_month} = Timex.DateFormat.format(date, "{YYYY}-{M}")
+    {:ok, label} = Timex.DateFormat.format(date, "%b %Y", :strftime)
+
+    %{date: current_month, label: label}
+  end
+
+  def next_month(date) do
+    date = Timex.Date.shift(date, months: 1)
+
+    {:ok, next_month} = Timex.DateFormat.format(date, "{YYYY}-{M}")
+    {:ok, label} = Timex.DateFormat.format(date, "%b %Y", :strftime)
+
+    %{date: next_month, label: label}
+  end
+
+  def previous_month(date) do
+    date = Timex.Date.shift(date, months: -1)
+
+    {:ok, previous_month} = Timex.DateFormat.format(date, "{YYYY}-{M}")
+    {:ok, label} = Timex.DateFormat.format(date, "%b %Y", :strftime)
+
+    %{date: previous_month, label: label}
+  end
+end

--- a/lib/ex_money/rule_processor.ex
+++ b/lib/ex_money/rule_processor.ex
@@ -60,6 +60,7 @@ defmodule ExMoney.RuleProcessor do
   defp withdraw_to_cash(rule, transaction, transaction_info) do
     {:ok, re} = Regex.compile(rule.pattern, "i")
     withdraw_category = Category.by_name("withdraw") |> Repo.one
+
     account = Repo.get(Account, rule.target_id)
 
     if Regex.match?(re, transaction_description(transaction, transaction_info)) &&
@@ -78,10 +79,10 @@ defmodule ExMoney.RuleProcessor do
         )
         |> Repo.insert!
 
-        Transaction.update_changeset(transaction, %{rule_applied: true})
+        Transaction.update_changeset(transaction, %{rule_applied: true, category_id: withdraw_category.id})
         |> Repo.update!
 
-        # transaction.amount is negative, sub with something with negative => add
+        # transaction.amount is negative, sub with something negative -> add
         new_balance = Decimal.sub(account.balance, transaction.amount)
         Account.update_custom_changeset(account, %{balance: new_balance})
         |> Repo.update!

--- a/mix.lock
+++ b/mix.lock
@@ -34,5 +34,5 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "timex": {:hex, :timex, "1.0.2", "a07f2234298749c0eeede7e6da2534acf35c2c4529c4240d390828953aafd038", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
-  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
+  "tzdata": {:hex, :tzdata, "0.5.12", "1c17b68692c6ba5b6ab15db3d64cc8baa0f182043d5ae9d4b6d35d70af76f67b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
   "uuid": {:hex, :uuid, "1.1.4", "36c7734e4c8e357f2f67ba57fb61799d60c20a7f817b104896cca64b857e3686", [:mix], []}}

--- a/priv/repo/migrations/20170425203553_add_include_to_budget_to_accounts.exs
+++ b/priv/repo/migrations/20170425203553_add_include_to_budget_to_accounts.exs
@@ -1,0 +1,9 @@
+defmodule ExMoney.Repo.Migrations.AddIncludeToBudgetToAccounts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:accounts) do
+      add :include_to_budget, :boolean
+    end
+  end
+end

--- a/web/controllers/mobile/setting/budget_controller.ex
+++ b/web/controllers/mobile/setting/budget_controller.ex
@@ -1,0 +1,30 @@
+defmodule ExMoney.Mobile.Setting.BudgetController do
+  use ExMoney.Web, :controller
+
+  alias ExMoney.{Account, Repo}
+
+  plug Guardian.Plug.EnsureAuthenticated, handler: ExMoney.Guardian.Mobile.Unauthenticated
+  plug :put_layout, "mobile.html"
+
+  def index(conn, _params) do
+    accounts = Repo.all(Account)
+    render conn, :index, accounts: accounts
+  end
+
+  def setup(conn, params) do
+    account = Repo.get!(Account, params["account_id"])
+
+    budget_accounts = Account.in_budget |> Repo.all
+
+    if budget_accounts == [] or List.first(budget_accounts).currency_code == account.currency_code do
+      update_params = %{include_to_budget: !account.include_to_budget}
+      Account.update_custom_changeset(account, update_params)
+      |> Repo.update!
+
+      send_resp(conn, 200, Poison.encode!(update_params))
+    else
+      msg = Poison.encode!(%{msg: "All budget accounts must have the same currency"})
+      send_resp(conn, 422, msg)
+    end
+  end
+end

--- a/web/controllers/mobile/setting_controller.ex
+++ b/web/controllers/mobile/setting_controller.ex
@@ -1,0 +1,10 @@
+defmodule ExMoney.Mobile.SettingController do
+  use ExMoney.Web, :controller
+
+  plug Guardian.Plug.EnsureAuthenticated, handler: ExMoney.Guardian.Mobile.Unauthenticated
+  plug :put_layout, "mobile.html"
+
+  def index(conn, _params) do
+    render conn, :index
+  end
+end

--- a/web/controllers/mobile/transaction_controller.ex
+++ b/web/controllers/mobile/transaction_controller.ex
@@ -1,5 +1,7 @@
 defmodule ExMoney.Mobile.TransactionController do
   use ExMoney.Web, :controller
+
+  alias ExMoney.DateHelper
   alias ExMoney.{Repo, Transaction, Category, Account, TransactionInfo, FavouriteTransaction}
 
   plug Guardian.Plug.EnsureAuthenticated, handler: ExMoney.Guardian.Mobile.Unauthenticated
@@ -12,9 +14,10 @@ defmodule ExMoney.Mobile.TransactionController do
       nil -> [category.id | Repo.all(Category.sub_categories_by_id(category.id))]
       _parent_id -> [category.id]
     end
-    parsed_date = parse_date(date)
-    from = first_day_of_month(parsed_date)
-    to = last_day_of_month(parsed_date)
+
+    parsed_date = DateHelper.parse_date(date)
+    from = DateHelper.first_day_of_month(parsed_date)
+    to = DateHelper.last_day_of_month(parsed_date)
 
     transactions = Transaction.by_month_by_category(account_id, from, to, category_ids)
     |> Repo.all
@@ -33,12 +36,47 @@ defmodule ExMoney.Mobile.TransactionController do
     end |> URI.encode_www_form
 
     render conn, :index,
-      currency_label: account.currency_label,
       transactions: transactions,
       date: %{label: formatted_date, value: date},
       category: category.humanized_name,
       from: from,
-      account_id: account.id
+      slug: "accounts/#{account.id}"
+  end
+
+  def index(conn, %{"date" => date, "category_id" => category_id}) do
+    category = Repo.get!(Category, category_id)
+    category_ids = case category.parent_id do
+      nil -> [category.id | Repo.all(Category.sub_categories_by_id(category.id))]
+      _parent_id -> [category.id]
+    end
+
+    parsed_date = DateHelper.parse_date(date)
+    from = DateHelper.first_day_of_month(parsed_date)
+    to = DateHelper.last_day_of_month(parsed_date)
+
+    budget_account_ids = Account.in_budget
+    |> Repo.all
+    |> Enum.map(fn(acc) -> acc.id end)
+
+    transactions = Transaction.by_month_by_category(budget_account_ids, from, to, category_ids)
+    |> Repo.all
+    |> Enum.group_by(fn(transaction) ->
+      transaction.made_on
+    end)
+    |> Enum.sort(fn({date_1, _transactions}, {date_2, _transaction}) ->
+      Ecto.Date.compare(date_1, date_2) != :lt
+    end)
+
+    {:ok, formatted_date} = Timex.DateFormat.format(parsed_date, "%b %Y", :strftime)
+
+    from = URI.encode_www_form("/m/budget?date=#{date}")
+
+    render conn, :index,
+      transactions: transactions,
+      date: %{label: formatted_date, value: date},
+      category: category.humanized_name,
+      from: from,
+      slug: "budget"
   end
 
   def new(conn, _params) do
@@ -111,7 +149,7 @@ defmodule ExMoney.Mobile.TransactionController do
       "user_id" => fav_tr.user_id,
       "category_id" => fav_tr.category_id,
       "account_id" => fav_tr.account_id,
-      "made_on" => Ecto.Date.from_erl(today()),
+      "made_on" => Ecto.Date.from_erl(DateHelper.today),
       "type" => "expense"
     }
     changeset = Transaction.changeset_custom(%Transaction{}, transaction_params)
@@ -176,25 +214,6 @@ defmodule ExMoney.Mobile.TransactionController do
     end
   end
 
-  defp parse_date(month) do
-    {:ok, date} = Timex.DateFormat.parse(month, "{YYYY}-{0M}")
-    date
-  end
-
-  defp first_day_of_month(date) do
-    Timex.Date.from({{date.year, date.month, 0}, {0, 0, 0}})
-    |> Timex.DateFormat.format("%Y-%m-%d", :strftime)
-    |> elem(1)
-  end
-
-  defp last_day_of_month(date) do
-    days_in_month = Timex.Date.days_in_month(date)
-
-    Timex.Date.from({{date.year, date.month, days_in_month}, {23, 59, 59}})
-    |> Timex.DateFormat.format("%Y-%m-%d", :strftime)
-    |> elem(1)
-  end
-
   defp categories_list do
     categories_dict = Repo.all(Category)
 
@@ -219,10 +238,5 @@ defmodule ExMoney.Mobile.TransactionController do
     else
       "/m/dashboard"
     end
-  end
-
-  defp today() do
-    {today, _} = :calendar.local_time()
-    today
   end
 end

--- a/web/controllers/mobile/transaction_controller.ex
+++ b/web/controllers/mobile/transaction_controller.ex
@@ -232,7 +232,8 @@ defmodule ExMoney.Mobile.TransactionController do
   defp validate_from_param(from) do
     if String.match?(from, ~r/\A\/m\/accounts\/\d+\/(expenses|income)\?date=\d{4}-\d{1,2}\z/) or
       String.match?(from, ~r/\A\/m\/transactions\?date=\d{4}-\d{1,2}\&category_id=\d+\&account_id=\d+\z/) or
-      String.match?(from, ~r/\A\/m\/accounts\/\d+\z/) do
+      String.match?(from, ~r/\A\/m\/accounts\/\d+\z/) or
+      String.match?(from, ~r/\A\/m\/budget\?date=\d{4}-\d{1,2}\z/) do
 
       from
     else

--- a/web/models/account.ex
+++ b/web/models/account.ex
@@ -11,6 +11,7 @@ defmodule ExMoney.Account do
     field :currency_code, :string
     field :currency_label, :string
     field :show_on_dashboard, :boolean
+    field :include_to_budget, :boolean
 
     belongs_to :login, ExMoney.Login,
       foreign_key: :saltedge_login_id,
@@ -43,7 +44,7 @@ defmodule ExMoney.Account do
 
   def update_custom_changeset(model, params \\ %{}) do
     model
-    |> cast(params, ~w(), ~w(name balance currency_code currency_label show_on_dashboard))
+    |> cast(params, ~w(), ~w(name balance currency_code currency_label show_on_dashboard include_to_budget))
   end
 
   def update_saltedge_changeset(model, params \\ %{}) do
@@ -63,9 +64,15 @@ defmodule ExMoney.Account do
     from a in Account, where: a.id in ^(ids)
   end
 
-  def show_on_dashboard() do
+  def show_on_dashboard do
     from acc in Account,
       where: acc.show_on_dashboard == true,
+      order_by: acc.name
+  end
+
+  def in_budget do
+    from acc in Account,
+      where: acc.include_to_budget == true,
       order_by: acc.name
   end
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -81,6 +81,16 @@ defmodule ExMoney.Router do
     resources "/favourite_transactions", FavouriteTransactionController do
       put "/fav", FavouriteTransactionController, :fav, as: :fav, param: "id"
     end
+
+    get "/budget", BudgetController, :index
+    get "/budget/expenses", BudgetController, :expenses
+    get "/budget/income", BudgetController, :income
+
+    scope "/settings", as: :setting do
+      get "/", SettingController, :index
+      resources "/budget", Setting.BudgetController, only: [:index]
+      put "/budget/setup", Setting.BudgetController, :setup
+    end
   end
 
   scope "/saltedge", as: :saltedge do

--- a/web/templates/layout/mobile.html.eex
+++ b/web/templates/layout/mobile.html.eex
@@ -25,17 +25,17 @@
           <div class="card-content">
             <div class="list-block">
               <ul>
-                <a href="/m/dashboard" class="item-link item-content close-panel no-animation" data-force="true" data-ignore-cache="true">
+                <a href="/m/dashboard" class="item-link item-content close-panel no-animation" data-ignore-cache="true">
                   <div class="item-inner">
                     <div class="item-title">Dashboard</div>
                   </div>
                 </a>
-                <a href="/m/budget" class="item-link item-content close-panel no-animation" data-force="true" data-ignore-cache="true">
+                <a href="/m/budget" class="item-link item-content close-panel no-animation" data-ignore-cache="true">
                   <div class="item-inner">
                     <div class="item-title">Budget</div>
                   </div>
                 </a>
-                <a href="/m/settings" class="item-link item-content close-panel no-animation" data-force="true" data-ignore-cache="true">
+                <a href="/m/settings" class="item-link item-content close-panel no-animation" data-ignore-cache="true">
                   <div class="item-inner">
                     <div class="item-title">Settings</div>
                   </div>

--- a/web/templates/layout/mobile.html.eex
+++ b/web/templates/layout/mobile.html.eex
@@ -18,6 +18,38 @@
   </head>
 
   <body>
+    <div class="panel-overlay"></div>
+    <div class="panel panel-left panel-reveal" style="background: #bfbfc5;">
+        <div class="card">
+          <div class="card-header"><strong>ExMoney</strong></div>
+          <div class="card-content">
+            <div class="list-block">
+              <ul>
+                <a href="/m/dashboard" class="item-link item-content close-panel no-animation" data-force="true" data-ignore-cache="true">
+                  <div class="item-inner">
+                    <div class="item-title">Dashboard</div>
+                  </div>
+                </a>
+                <a href="/m/budget" class="item-link item-content close-panel no-animation" data-force="true" data-ignore-cache="true">
+                  <div class="item-inner">
+                    <div class="item-title">Budget</div>
+                  </div>
+                </a>
+                <a href="/m/settings" class="item-link item-content close-panel no-animation" data-force="true" data-ignore-cache="true">
+                  <div class="item-inner">
+                    <div class="item-title">Settings</div>
+                  </div>
+                </a>
+                <a href="#" class="item-link item-content close-panel">
+                  <div class="item-inner">
+                    <div class="item-title">About</div>
+                  </div>
+                </a>
+              </ul>
+            </div>
+          </div>
+        </div>
+    </div>
     <%= render @view_module, @view_template, assigns %>
 
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>

--- a/web/templates/mobile/account/income.html.eex
+++ b/web/templates/mobile/account/income.html.eex
@@ -1,5 +1,5 @@
 <div class="pages">
-  <div class="page navbar-fixed" data-page="income-screen">
+  <div class="page navbar-fixed" data-page="account-income-screen">
     <div class="navbar">
       <div class="navbar-inner">
         <div class="left">

--- a/web/templates/mobile/account/show.html.eex
+++ b/web/templates/mobile/account/show.html.eex
@@ -1,7 +1,7 @@
 <div class="views">
   <div class="view view-main">
     <div class="pages">
-      <div class="page navbar-fixed" data-page="account-screen" >
+      <div class="page navbar-fixed" data-page="account-screen">
         <div class="navbar">
           <div class="navbar-inner">
             <div class="left">

--- a/web/templates/mobile/budget/expenses.html.eex
+++ b/web/templates/mobile/budget/expenses.html.eex
@@ -1,9 +1,9 @@
 <div class="pages">
-  <div class="page navbar-fixed" data-page="account-expenses-screen">
+  <div class="page navbar-fixed" data-page="budget-expenses-screen">
     <div class="navbar">
       <div class="navbar-inner">
         <div class="left">
-          <a href="/m/accounts/<%= @account.id %>?date=<%= @date.value %>" class="link back" data-force="true" data-ignore-cache="true">
+          <a href="/m/budget?date=<%= @date.value %>" class="link back" data-force="true" data-ignore-cache="true">
             <i class="icon icon-back"></i>&nbsp; Back
           </a>
         </div>
@@ -15,8 +15,8 @@
         <%= render ExMoney.SharedView, "transactions_list.html",
           transactions: @expenses,
           new_transaction_ids: [],
-          account: @account,
-          account_balance: @account_balance,
+          account: nil,
+          account_balance: nil,
           from: @from %>
       </div>
     </div>

--- a/web/templates/mobile/budget/income.html.eex
+++ b/web/templates/mobile/budget/income.html.eex
@@ -1,22 +1,22 @@
 <div class="pages">
-  <div class="page navbar-fixed" data-page="account-expenses-screen">
+  <div class="page navbar-fixed" data-page="budget-income-screen">
     <div class="navbar">
       <div class="navbar-inner">
         <div class="left">
-          <a href="/m/accounts/<%= @account.id %>?date=<%= @date.value %>" class="link back" data-force="true" data-ignore-cache="true">
+          <a href="/m/budget?date=<%= @date.value %>" class="link back" data-force="true" data-ignore-cache="true">
             <i class="icon icon-back"></i>&nbsp; Back
           </a>
         </div>
-        <div class="center">Expenses for <%= @date.label %></div>
+        <div class="center">Income for <%= @date.label %></div>
       </div>
     </div>
     <div class="page-content hide-navbar-on-scroll">
       <div class="list-block reduced-margin media-list">
         <%= render ExMoney.SharedView, "transactions_list.html",
-          transactions: @expenses,
+          transactions: @income,
           new_transaction_ids: [],
-          account: @account,
-          account_balance: @account_balance,
+          account: nil,
+          account_balance: nil,
           from: @from %>
       </div>
     </div>

--- a/web/templates/mobile/budget/index.html.eex
+++ b/web/templates/mobile/budget/index.html.eex
@@ -14,7 +14,7 @@
       <div class="content-block-title" align="center">
         <div class="row">
           <div class="col-33" align="left">
-            <a href="/m/budget?date=<%= @previous_month.date %>" class="link back" data-force="true">
+            <a href="/m/budget?date=<%= @previous_month.date %>" class="link back" data-ignore-cache="true" data-force="true">
               &#8592; <%= @previous_month.label %>
             </a>
           </div>

--- a/web/templates/mobile/budget/index.html.eex
+++ b/web/templates/mobile/budget/index.html.eex
@@ -1,0 +1,98 @@
+<div class="pages">
+  <div class="page navbar-fixed" data-page="budget-screen">
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="left">
+          <a href="#" class="link open-panel" data-panel="left">
+            <i class="icon icon-bars"></i>
+          </a>
+        </div>
+        <div class="center">Budget</div>
+      </div>
+    </div>
+    <div class="page-content hide-navbar-on-scroll">
+      <div class="content-block-title" align="center">
+        <div class="row">
+          <div class="col-33" align="left">
+            <a href="/m/budget?date=<%= @previous_month.date %>" class="link back" data-force="true">
+              &#8592; <%= @previous_month.label %>
+            </a>
+          </div>
+          <div class="col-33" id="current_date" data-current-date="<%= @current_month.date %>">
+            <%= @current_month.label %>
+          </div>
+          <div class="col-33" align="right">
+            <a href="/m/budget?date=<%= @next_month.date %>" class="link" data-ignore-cache="true">
+              <%= @next_month.label %> &#8594;
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="list-block">
+          <ul>
+            <li class="item-content">
+              <div class="item-inner">
+                <div class="item-title">Expenses</div>
+                <div class="item-after" style="color: black">
+                  <a href='/m/budget/expenses?date=<%= @current_month.date %>' data-ignore-cache="true">
+                    <%= expenses(@month_transactions) %> <%= @currency_label %>
+                  </a>
+                </div>
+              </div>
+            </li>
+            <li class="item-content">
+              <div class="item-inner">
+                <div class="item-title">Income</div>
+                <div class="item-after" style="color: black">
+                  <a href='/m/budget/income?date=<%= @current_month.date %>' data-ignore-cache="true">
+                    <%= income(@month_transactions) %> <%= @currency_label %>
+                  </a>
+                </div>
+              </div>
+            </li>
+            <li class="item-content">
+              <div class="item-inner">
+                <div class="item-title">Balance</div>
+                <div class="item-after" style="color: black">
+                  <%= balance(@month_transactions) %> <%= @currency_label %>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div class="row">
+          <div class="container horizontal flat">
+            <h3>Top Expenses</h3>
+            <%= for {{id, category, color, width, amount}, sub_categories} <- categories_chart_data(@categories) do %>
+              <div class="progress-bar horizontal accordion-item">
+                <a href="#" class="category-bar item-content item-link" style="color: black" data-category-id="<%= id %>">
+                  <div class="progress-track">
+                    <div class="progress-fill" style="width:<%= width %>; background: <%= color %>">
+                      <span><%= Float.to_string(amount, compact: true, decimals: 1) %>&nbsp;<%= raw category %></span>
+                    </div>
+                  </div>
+                </a>
+                <div class="accordion-item-content" style="margin-left: 20px">
+                  <%= if Enum.count(sub_categories) > 0 do %>
+                    <div class="progress-bar horizontal">
+                      <%= for {id, category, _color, width, amount} <- sub_categories do %>
+                        <a href="#" class="category-bar" style="color: black" data-category-id="<%= id %>">
+                          <div class="progress-track" style="margin-top: 10px">
+                            <div class="progress-fill" style="width:<%= width %>; background: #b3b3b3">
+                              <span><%= Float.to_string(amount, compact: true, decimals: 1) %>&nbsp;<%= raw category %></span>
+                            </div>
+                          </div>
+                        </a>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/web/templates/mobile/budget/setup.html.eex
+++ b/web/templates/mobile/budget/setup.html.eex
@@ -1,0 +1,23 @@
+<div class="pages">
+  <div class="page navbar-fixed" data-page="budget-setup-page">
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="left">
+          <a href="#" class="link open-panel" data-panel="left">
+            <i class="icon icon-bars"></i>
+          </a>
+        </div>
+        <div class="center">Budget</div>
+      </div>
+    </div>
+    <div class="page-content">
+      <div class="card">
+        <div class="card-content">
+          <div class="card-content-inner" style="text-align: center">
+            To start using Budget, <br/>you need to <a href="/m/settings/budget" data-force="true" data-ignore-cache="true">setup</a> it first.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/web/templates/mobile/dashboard/overview.html.eex
+++ b/web/templates/mobile/dashboard/overview.html.eex
@@ -4,6 +4,11 @@
       <div class="page navbar-fixed" data-page="overview-screen">
         <div class="navbar">
           <div class="navbar-inner">
+            <div class="left">
+              <a href="#" class="link open-panel" data-panel="left">
+                <i class="icon icon-bars"></i>
+              </a>
+            </div>
             <div class="center">ExMoney</div>
           </div>
         </div>

--- a/web/templates/mobile/setting/budget/index.html.eex
+++ b/web/templates/mobile/setting/budget/index.html.eex
@@ -1,0 +1,38 @@
+<div class="pages">
+  <div class="page navbar-fixed" data-page="settings-budget-page">
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="left">
+          <a href="/m/settings" class="link back" data-reload="true" data-force="true" data-ignore-cache="true">
+            <i class="icon icon-back"></i>&nbsp; Back
+          </a>
+        </div>
+        <div class="center">Settings &rarr; Budget</div>
+      </div>
+    </div>
+    <div class="page-content">
+      <div class="content-block">Swipe right to include account to Budget</div>
+      <div class="list-block">
+        <ul>
+        <%= for account <- @accounts do %>
+        <li class="swipeout budget-account-li">
+          <div class="swipeout-content">
+            <div class="item-content">
+              <div class="item-inner">
+                <div class="item-title" id="account_tr_<%= account.id %>"><%= account.name %> <small><%= account.currency_code %></small></div>
+                <%= if account.include_to_budget do %>
+                  <div class='item-after'><i class='f7-icons color-blue'>check</i></div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+          <div class="swipeout-actions-left">
+            <a href="#" data-id="<%= account.id %>" class="bg-blue budget-account"><i class="f7-icons">check</i></a>
+          </div>
+        </li>
+        <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/web/templates/mobile/setting/index.html.eex
+++ b/web/templates/mobile/setting/index.html.eex
@@ -15,7 +15,7 @@
         <div class="card-content">
           <div class="list-block">
             <ul>
-              <a href="/m/settings/budget" class="item-link item-content" data-force="true" data-ignore-cache="true">
+              <a href="/m/settings/budget" class="item-link item-content" data-ignore-cache="true">
                 <div class="item-inner">
                   <div class="item-title">Budget</div>
                 </div>

--- a/web/templates/mobile/setting/index.html.eex
+++ b/web/templates/mobile/setting/index.html.eex
@@ -1,0 +1,29 @@
+<div class="pages">
+  <div class="page navbar-fixed" data-page="setting-expenses-page">
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="left">
+          <a href="#" class="link open-panel" data-panel="left">
+            <i class="icon icon-bars"></i>
+          </a>
+        </div>
+        <div class="center">Settings</div>
+      </div>
+    </div>
+    <div class="page-content">
+      <div class="card">
+        <div class="card-content">
+          <div class="list-block">
+            <ul>
+              <a href="/m/settings/budget" class="item-link item-content" data-force="true" data-ignore-cache="true">
+                <div class="item-inner">
+                  <div class="item-title">Budget</div>
+                </div>
+              </a>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/web/templates/mobile/transaction/index.html.eex
+++ b/web/templates/mobile/transaction/index.html.eex
@@ -3,7 +3,7 @@
     <div class="navbar">
       <div class="navbar-inner">
         <div class="left">
-          <a href="/m/accounts/<%= @account_id %>?date=<%= @date.value %>" class="link back" data-force="true" data-ignore-cache="true">
+          <a href="/m/<%= @slug %>?date=<%= @date.value %>" class="link back" data-force="true" data-ignore-cache="true">
             <i class="icon icon-back"></i>&nbsp; Back
           </a>
         </div>

--- a/web/views/mobile/budget_view.ex
+++ b/web/views/mobile/budget_view.ex
@@ -1,0 +1,146 @@
+defmodule ExMoney.Mobile.BudgetView do
+  use ExMoney.Web, :view
+
+  alias ExMoney.{Category, Repo}
+
+  def categories_chart_data(categories) when map_size(categories) == 0 do
+    []
+  end
+
+  # FIXME Oh my, that's got complicated.
+  # I hope there is a better way to generate data for the chart.
+  def categories_chart_data(categories) do
+    parent_categories = Enum.map(categories, fn({_id, category}) -> category.parent_id end)
+    |> Enum.reject(&(is_nil(&1)))
+    |> Category.by_ids
+    |> Repo.all
+    |> Enum.reduce(%{}, fn(category, acc) ->
+      case Map.has_key?(acc, category.id) do
+        true -> acc
+        false -> Map.put(acc, category.id, category)
+      end
+    end)
+
+    categories_tree = Enum.reduce(categories, %{}, fn({id, category}, acc) ->
+      if is_nil(category.parent_id) do
+        case Map.has_key?(acc, id) do
+          false -> Map.put(acc, id, [])
+          true -> acc
+        end
+      else
+        case Map.has_key?(acc, category.parent_id) do
+          false -> Map.put(acc, category.parent_id, [id])
+          true ->
+            sub_categories = Map.get(acc, category.parent_id, [])
+            Map.put(acc, category.parent_id, [id | sub_categories])
+        end
+      end
+    end)
+
+    max_amount = Enum.reduce(categories_tree, [], fn({id, sub_category_ids}, acc) ->
+      category = parent_categories[id] || categories[id]
+
+      case sub_category_ids do
+        [] ->
+          [category.amount | acc]
+        _ ->
+          sub_amount = Enum.reduce(sub_category_ids, 0, fn(sub_category_id, acc) ->
+            acc + categories[sub_category_id].amount
+          end)
+
+          total_amount = if categories[category.id] do
+            sub_amount + categories[category.id].amount
+          else
+            sub_amount
+          end
+
+          [total_amount | acc]
+      end
+    end) |> Enum.max
+
+    Enum.reduce(categories_tree, [], fn({id, sub_category_ids}, acc) ->
+      category = parent_categories[id] || categories[id]
+      amount = case sub_category_ids do
+        [] -> category.amount
+        _ ->
+          sub_categories_sum = Enum.reduce(sub_category_ids, 0, fn(sub_category_id, acc) ->
+            acc + categories[sub_category_id].amount
+          end)
+
+          if categories[category.id] do
+            sub_categories_sum + categories[category.id].amount
+          else
+            sub_categories_sum
+          end
+      end
+
+      sub_categories = Enum.reduce(sub_category_ids, [], fn(sub_category_id, acc) ->
+        sub_category = categories[sub_category_id]
+        sub_category = add_width(sub_category, sub_category.amount, amount)
+
+        if sub_category do
+          [sub_category | acc]
+        else
+          acc
+        end
+      end)
+      |> Enum.sort(fn(
+        {_id_1, _cat_1, _color_1, _width_1, amount_1},
+        {_id_2, _cat_2, _color_2, _width_2, amount_2}) ->
+          amount_1 > amount_2
+      end)
+
+      category = add_width(category, amount, max_amount)
+
+      if category do
+        [{category, sub_categories} | acc]
+      else
+        acc
+      end
+    end)
+    |> Enum.sort(fn(
+      {{_id_1, _cat_1, _color_1, _width_1, amount_1}, _sub_categories_1},
+      {{_id_2, _cat_2, _color_2, _width_2, amount_2}, _sub_categories_2}) ->
+        amount_1 > amount_2
+    end)
+  end
+
+  defp add_width(category, amount, max_amount) do
+    percent = (amount * 100) / max_amount
+    |> Float.round(0)
+    |> Float.to_string(compact: true, decimals: 0)
+
+    if percent == "0" do
+      nil
+    else
+      html_name = String.replace(category.humanized_name, " ", "&nbsp;")
+      {category.id, html_name, category.css_color, "#{percent}%", amount}
+    end
+  end
+
+  def balance(transactions) do
+    Enum.reduce transactions, Decimal.new(0), fn(tr, acc) ->
+      Decimal.add(acc, tr.amount)
+    end
+  end
+
+  def expenses(transactions) do
+    transactions
+    |> Enum.reject(fn(tr) ->
+      Decimal.compare(tr.amount, Decimal.new(0)) != Decimal.new(-1) or tr.category.name == "withdraw"
+    end)
+    |> Enum.reduce(Decimal.new(0), fn(transaction, acc) ->
+      Decimal.add(acc, transaction.amount)
+    end)
+  end
+
+  def income(transactions) do
+    transactions
+    |> Enum.reject(fn(tr) ->
+      Decimal.compare(tr.amount, Decimal.new(0)) == Decimal.new(-1) or tr.category.name == "withdraw"
+    end)
+    |> Enum.reduce(Decimal.new(0), fn(transaction, acc) ->
+      Decimal.add(acc, transaction.amount)
+    end)
+  end
+end

--- a/web/views/mobile/setting/budget_view.ex
+++ b/web/views/mobile/setting/budget_view.ex
@@ -1,0 +1,3 @@
+defmodule ExMoney.Mobile.Setting.BudgetView do
+  use ExMoney.Web, :view
+end

--- a/web/views/mobile/setting_view.ex
+++ b/web/views/mobile/setting_view.ex
@@ -1,0 +1,3 @@
+defmodule ExMoney.Mobile.SettingView do
+  use ExMoney.Web, :view
+end


### PR DESCRIPTION
One of the issues I have with ex_money is that 'Top Expenses' graph is available only per account basis. Of course it useful, but to have a better picture how much money I spent this month I need the same 'Top Expenses' graph both for my bank account with transactions coming from Saltedge and my cash account with transaction I create manually.

Here I'm trying to solve this issue with new 'Budget' page. 'Budget' page isn't the best name for this page, but naming is hard. First, it's necessary to setup 'budget'. 'Budget' setup is just selecting which accounts should be included to the 'budget'. For now you can choose only accounts with the same currency. After this trivial setup one can see Budget page, which looks exactly like accounts page, but it shows data for all accounts in 'budget'.

![budget](https://cloud.githubusercontent.com/assets/1541059/25595302/8b86722c-2ec4-11e7-910b-5c01f9904800.png)

You can still open categories on graph using long tap and open 'expenses' and 'income' pages as you do on account page.

Budget page excludes transactions with 'withdraw' category for obvious reasons. Btw 'withdraw_to_cash' rule in rule_processor now applies 'withdraw' category to both saltedge transaction and new cash transaction, so I can exclude these transactions from budget calculations easily.

Also I had to add a menu (which looks... suboptimal 😬) in order to add new 'budget' and 'settings' pages.
![menu](https://cloud.githubusercontent.com/assets/1541059/25595425/134dd6a0-2ec5-11e7-9048-8399b1439f4c.png)

I wish I could combine current 'dashboard' page with new 'budget' page in one page.
I'll play with this branch on my heroku instance for a while, maybe I can find better way to add 'show me how much money I spent this month' page to ex_money.