### PR TITLE
Ability to hide a category

### DIFF
--- a/priv/repo/migrations/20170520194853_add_hidden_to_categories.exs
+++ b/priv/repo/migrations/20170520194853_add_hidden_to_categories.exs
@@ -1,0 +1,9 @@
+defmodule ExMoney.Repo.Migrations.AddHiddenToCategories do
+  use Ecto.Migration
+
+  def change do
+    alter table(:categories) do
+      add :hidden, :boolean, default: false
+    end
+  end
+end

--- a/web/controllers/mobile/budget_controller.ex
+++ b/web/controllers/mobile/budget_controller.ex
@@ -2,7 +2,7 @@ defmodule ExMoney.Mobile.BudgetController do
   use ExMoney.Web, :controller
 
   alias ExMoney.DateHelper
-  alias ExMoney.{Repo, Transaction, Account, AccountsBalanceHistory}
+  alias ExMoney.{Repo, Transaction, Account}
 
   plug Guardian.Plug.EnsureAuthenticated, handler: ExMoney.Guardian.Mobile.Unauthenticated
   plug :put_layout, "mobile.html"

--- a/web/controllers/mobile/setting/category_controller.ex
+++ b/web/controllers/mobile/setting/category_controller.ex
@@ -1,0 +1,74 @@
+defmodule ExMoney.Mobile.Setting.CategoryController do
+  use ExMoney.Web, :controller
+
+  alias ExMoney.{Category, Repo}
+
+  plug Guardian.Plug.EnsureAuthenticated, handler: ExMoney.Guardian.Mobile.Unauthenticated
+  plug :put_layout, "mobile.html"
+
+  def index(conn, _params) do
+    categories = Repo.all(Category.list_with_hidden)
+
+    parent_categories = Enum.filter(categories, fn(c) -> is_nil(c.parent_id) end)
+
+    sub_categories_map = Enum.reduce parent_categories, %{}, fn(c, acc) ->
+      sub_categories = Enum.filter(categories, fn(sub_c) -> sub_c.parent_id == c.id end)
+      Map.put(acc, c.id, sub_categories)
+    end
+
+    render conn, :index,
+      parent_categories: parent_categories,
+      sub_categories_map: sub_categories_map
+  end
+
+  def show(conn, %{"id" => id}) do
+    category = Repo.get!(Category, id)
+
+    render conn, :show, category: category
+  end
+
+  def new(conn, _params) do
+    parent_categories = Repo.all(Category.parents_with_hidden)
+    changeset = Category.changeset(%Category{})
+
+    render conn, :new,
+      changeset: changeset,
+      parent_categories: parent_categories
+  end
+
+  def create(conn, %{"category" => category_params}) do
+    changeset = Category.changeset(%Category{}, category_params)
+
+    case Repo.insert(changeset) do
+      {:ok, _category} ->
+        conn
+        |> put_flash(:info, "Category created successfully.")
+        |> redirect(to: mobile_setting_category_path(conn, :index))
+      {:error, changeset} ->
+        render(conn, :new, changeset: changeset, topbar: "settings", navigation: "categories")
+    end
+  end
+
+  def edit(conn, %{"id" => id}) do
+    parent_categories = Category.parents_with_hidden |> Repo.all
+    category = Repo.get(Category, id)
+    changeset = Category.update_changeset(category)
+
+    render conn, :edit,
+      category: category,
+      parent_categories: parent_categories,
+      changeset: changeset
+  end
+
+  def update(conn, %{"id" => id, "category" => category_params}) do
+    category = Repo.get!(Category, id)
+    changeset = Category.update_changeset(category, category_params)
+
+    case Repo.update(changeset) do
+      {:ok, _category} ->
+        send_resp(conn, 200, "")
+      {:error, _changeset} ->
+        send_resp(conn, 422, "Something went wrong, check server logs")
+    end
+  end
+end

--- a/web/controllers/mobile/transaction_controller.ex
+++ b/web/controllers/mobile/transaction_controller.ex
@@ -215,7 +215,7 @@ defmodule ExMoney.Mobile.TransactionController do
   end
 
   defp categories_list do
-    categories_dict = Repo.all(Category)
+    categories_dict = Category.visible |> Repo.all
 
     Enum.reduce(categories_dict, %{}, fn(category, acc) ->
       if is_nil(category.parent_id) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -90,6 +90,8 @@ defmodule ExMoney.Router do
       get "/", SettingController, :index
       resources "/budget", Setting.BudgetController, only: [:index]
       put "/budget/setup", Setting.BudgetController, :setup
+
+      resources "/categories", Setting.CategoryController, only: [:index, :edit, :update]
     end
   end
 

--- a/web/static/vendor/Framework7_custom/css/app.css
+++ b/web/static/vendor/Framework7_custom/css/app.css
@@ -49,6 +49,16 @@
   -webkit-filter: blur(5px);
 }
 
+.list-item-arrow {
+  padding-right: 35px;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D'0%200%2060%20120'%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%3E%3Cpath%20d%3D'm60%2061.5-38.25%2038.25-9.75-9.75%2029.25-28.5-29.25-28.5%209.75-9.75z'%20fill%3D'%23c7c7cc'%2F%3E%3C%2Fsvg%3E");
+  background-size: 10px 20px;
+  background-repeat: no-repeat;
+  background-position: 95% center;
+  background-position: -webkit-calc(100% - 15px) center;
+  background-position: calc(100% - 15px) center;
+}
+
 -moz-user-select: none;
 -webkit-user-select: none;
 user-select: none;

--- a/web/static/vendor/Framework7_custom/js/app.js
+++ b/web/static/vendor/Framework7_custom/js/app.js
@@ -355,6 +355,22 @@ exMoney.onPageInit('account-screen', function (page) {
   });
 });
 
+exMoney.onPageInit('edit-category-screen', function (page) {
+  $$('form.ajax-submit').on('submitted', function (e) {
+    var xhr = e.detail.xhr;
+
+    if (xhr.status == 200) {
+      mainView.router.back({
+        url: '/m/settings/categories',
+        ignoreCache: true,
+        force: true
+      });
+    } else {
+      exMoney.alert(xhr.responseText);
+    }
+  });
+});
+
 exMoney.onPageInit('edit-transaction-screen', function (page) {
   adjustSelectedCategory();
 

--- a/web/templates/mobile/dashboard/overview.html.eex
+++ b/web/templates/mobile/dashboard/overview.html.eex
@@ -19,7 +19,7 @@
             <i class="f7-icons">close</i>
           </a>
           <div class="speed-dial-buttons">
-            <a href="/m/favourite_transactions">
+            <a href="/m/favourite_transactions" data-ignore-cache="true">
               <i class="f7-icons" style="font-size: 22px">gear</i>
             </a>
             <%= if @fav_transaction do %>
@@ -27,7 +27,7 @@
                 <i class="f7-icons" style="font-size: 22px">heart</i>
               </a>
             <% end %>
-            <a href="/m/transactions/new" class="link" id="new_transaction_fab">
+            <a href="/m/transactions/new" class="link" id="new_transaction_fab" data-ignore-cache="true">
               <i class="f7-icons" style="font-size: 22px">compose</i>
             </a>
           </div>

--- a/web/templates/mobile/setting/category/edit.html.eex
+++ b/web/templates/mobile/setting/category/edit.html.eex
@@ -1,0 +1,74 @@
+<div class="pages">
+  <div class="page navbar-fixed" data-page="edit-category-screen">
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="left">
+          <a href="/m/settings/categories" class="link back" data-reload="true" data-force="true" data-ignore-cache="true">
+            <i class="icon icon-back"></i>&nbsp; Back
+          </a>
+        </div>
+        <div class="center">Edit category</div>
+      </div>
+    </div>
+    <div class="page-content">
+      <div class="list-block reduced-margin">
+        <%= form_for @changeset, mobile_setting_category_path(@conn, :update, @category), [method: :put, class: "ajax-submit"], fn f -> %>
+          <ul>
+            <%= if not is_nil(@category.parent_id) do %>
+              <li>
+                <a href="#" class="item-link smart-select smart-category-select" data-back-on-select="true" data-open-in="popup" data-searchbar="true" data-page-title="Parent Category">
+                  <%= render "parent_categories_list.html", categories: @parent_categories, selected: @category.parent_id %>
+                  <div class="item-content">
+                    <div class="item-inner">
+                      <div class="item-title">Parent</div>
+                    </div>
+                  </div>
+                </a>
+              </li>
+            <% end %>
+            <li class="align-top">
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title label">Name</div>
+                  <div class="item-input">
+                    <%= text_input(f, :name, placeholder: "Name", style: "text-align: right") %>
+                  </div>
+                </div>
+              </div>
+            </li>
+            <li class="align-top">
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title label">Human name</div>
+                  <div class="item-input">
+                    <%= text_input(f, :humanized_name, placeholder: "Humanized Name", style: "text-align: right") %>
+                  </div>
+                </div>
+              </div>
+            </li>
+            <li>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title label">Hidden</div>
+                  <div class="item-input" style="text-align: right">
+                    <%= checkbox(f, :hidden, style: "text-align: right") %>
+                  </div>
+                </div>
+              </div>
+            </li>
+          </ul>
+
+          <div class="content-block">
+            <div class="row">
+              <div class="col-25"></div>
+              <div class="col-50" align="center">
+                <button class="button active button-big" type="submit">Update</button>
+              </div>
+              <div class="col-25"></div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/web/templates/mobile/setting/category/index.html.eex
+++ b/web/templates/mobile/setting/category/index.html.eex
@@ -1,0 +1,34 @@
+<div class="pages">
+  <div class="page navbar-fixed" data-page="settings-categories-index-page">
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="left">
+          <a href="/m/settings" class="link back" data-reload="true" data-force="true" data-ignore-cache="true">
+            <i class="icon icon-back"></i>&nbsp; Back
+          </a>
+        </div>
+        <div class="center">Settings &rarr; Categories</div>
+      </div>
+    </div>
+    <div class="page-content">
+      <div class="list-block cards-list reduced-margin">
+        <%= for category <- @parent_categories do %>
+          <ul>
+            <li class="card">
+              <a href="/m/settings/categories/<%= category.id %>/edit" data-ignore-cache="true" class="item-link list-item-arrow">
+                <div class="card-header"><%= category.humanized_name %></div>
+              </a>
+              <div class="card-content">
+                <%= for sub_category <- @sub_categories_map[category.id] do %>
+                  <a href="/m/settings/categories/<%= sub_category.id %>/edit" data-ignore-cache="true" class="item-link list-item-arrow">
+                    <div class="card-content-inner" style="padding: 7px 0px 7px 20px"><%= sub_category.humanized_name %></div>
+                  </a>
+                <% end %>
+              </div>
+            </li>
+          </ul>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/web/templates/mobile/setting/category/parent_categories_list.html.eex
+++ b/web/templates/mobile/setting/category/parent_categories_list.html.eex
@@ -1,0 +1,7 @@
+<select class="form-control" id="category_parent_id" name="category[parent_id]">
+  <%= for {name, id} <- @categories do %>
+    <option <%= if id == @selected, do: "selected=selected" %> value="<%= id %>">
+      <%= name %>
+    </option>
+  <% end %>
+</select>

--- a/web/templates/mobile/setting/category/show.html.eex
+++ b/web/templates/mobile/setting/category/show.html.eex
@@ -1,0 +1,17 @@
+<div class="pages">
+  <div class="page navbar-fixed" data-page="settings-categories-index-page">
+    <div class="navbar">
+      <div class="navbar-inner">
+        <div class="left">
+          <a href="/m/settings/categories" class="link back" data-reload="true" data-force="true" data-ignore-cache="true">
+            <i class="icon icon-back"></i>&nbsp; Back
+          </a>
+        </div>
+        <div class="center">Settings &rarr; Categories</div>
+      </div>
+    </div>
+    <div class="page-content">
+      <%= @category.name %>
+    </div>
+  </div>
+</div>

--- a/web/templates/mobile/setting/index.html.eex
+++ b/web/templates/mobile/setting/index.html.eex
@@ -20,6 +20,12 @@
                   <div class="item-title">Budget</div>
                 </div>
               </a>
+
+              <a href="/m/settings/categories" class="item-link item-content" data-ignore-cache="true">
+                <div class="item-inner">
+                  <div class="item-title">Categories</div>
+                </div>
+              </a>
             </ul>
           </div>
         </div>

--- a/web/views/mobile/setting/category_view.ex
+++ b/web/views/mobile/setting/category_view.ex
@@ -1,0 +1,3 @@
+defmodule ExMoney.Mobile.Setting.CategoryView do
+  use ExMoney.Web, :view
+end


### PR DESCRIPTION
A new entry on Settings page. Now it's possible to edit a category: change name, parent or human name. Also it's possible to hide it, so you won't see it in the list when you're adding a new category. It should be helpful to hide those categories which you never use, for example Saltedge API provides 'Gas and Fuel' category, which I don't use because I don't have a car. Now I can hide it, so the list should be smaller, it will be loaded faster and therefore you can choose a category faster.