### PR TITLE
Do not show `withdraw` transactions in budget view

### DIFF
--- a/web/controllers/mobile/transaction_controller.ex
+++ b/web/controllers/mobile/transaction_controller.ex
@@ -43,7 +43,7 @@ defmodule ExMoney.Mobile.TransactionController do
       slug: "accounts/#{account.id}"
   end
 
-  def index(conn, %{"date" => date, "category_id" => category_id}) do
+  def index(conn, %{"date" => date, "category_id" => category_id, "type" => type}) do
     category = Repo.get!(Category, category_id)
     category_ids = case category.parent_id do
       nil -> [category.id | Repo.all(Category.sub_categories_by_id(category.id))]
@@ -58,7 +58,14 @@ defmodule ExMoney.Mobile.TransactionController do
     |> Repo.all
     |> Enum.map(fn(acc) -> acc.id end)
 
-    transactions = Transaction.by_month_by_category(budget_account_ids, from, to, category_ids)
+    query = case type do
+      "expenses" ->
+        Transaction.expenses_by_month_by_category(budget_account_ids, from, to, category_ids)
+      "income" ->
+        Transaction.income_by_month_by_category(budget_account_ids, from, to, category_ids)
+    end
+
+    transactions = query
     |> Repo.all
     |> Enum.group_by(fn(transaction) ->
       transaction.made_on

--- a/web/static/vendor/Framework7_custom/js/app.js
+++ b/web/static/vendor/Framework7_custom/js/app.js
@@ -344,7 +344,7 @@ exMoney.onPageInit('budget-screen', function (page) {
     var date = page.query.date || $$("#current_date").data("current-date");
 
     mainView.router.load({
-      url: '/m/transactions?category_id='+category_id+'&date='+date,
+      url: '/m/transactions?category_id='+category_id+'&date='+date+'&type=expenses',
       ignoreCache: true
     });
   });

--- a/web/views/mobile/budget_view.ex
+++ b/web/views/mobile/budget_view.ex
@@ -29,7 +29,8 @@ defmodule ExMoney.Mobile.BudgetView do
         end
       else
         case Map.has_key?(acc, category.parent_id) do
-          false -> Map.put(acc, category.parent_id, [id])
+          false ->
+            Map.put(acc, category.parent_id, [id])
           true ->
             sub_categories = Map.get(acc, category.parent_id, [])
             Map.put(acc, category.parent_id, [id | sub_categories])
@@ -60,6 +61,7 @@ defmodule ExMoney.Mobile.BudgetView do
 
     Enum.reduce(categories_tree, [], fn({id, sub_category_ids}, acc) ->
       category = parent_categories[id] || categories[id]
+
       amount = case sub_category_ids do
         [] -> category.amount
         _ ->


### PR DESCRIPTION
Because `withdraw` transactions are neither expense nor income. These
transactions are about transferring some money from bank account to cash
account, then you buy something using cash account, which means using
this money which were transferred to `cash` account.