### PR TITLE
Move `TransactionInfo` table to `extra` column in `Transaction`

### DIFF
--- a/lib/ex_money/saltedge/transactions_worker.ex
+++ b/lib/ex_money/saltedge/transactions_worker.ex
@@ -3,7 +3,7 @@ defmodule ExMoney.Saltedge.TransactionsWorker do
 
   require Logger
 
-  alias ExMoney.{Repo, Transaction, TransactionInfo, Category, Account}
+  alias ExMoney.{Repo, Transaction, Category, Account}
 
   def start_link(_opts \\ []) do
     GenServer.start_link(__MODULE__, :ok, name: :transactions_worker)
@@ -128,14 +128,7 @@ defmodule ExMoney.Saltedge.TransactionsWorker do
 
         changeset = Transaction.changeset(%Transaction{}, se_tran)
         {:ok, inserted_transaction} = Repo.transaction fn ->
-          transaction = Repo.insert!(changeset)
-
-          extra = Map.put(se_tran["extra"], "transaction_id", transaction.id)
-          transaction_info_changeset = TransactionInfo.changeset(%TransactionInfo{}, extra)
-
-          Repo.insert!(transaction_info_changeset)
-
-          transaction
+          Repo.insert!(changeset)
         end
         GenServer.cast(:rule_processor, {:process, inserted_transaction.id})
 

--- a/lib/ex_money/web/controllers/mobile/transaction_controller.ex
+++ b/lib/ex_money/web/controllers/mobile/transaction_controller.ex
@@ -2,7 +2,7 @@ defmodule ExMoney.Web.Mobile.TransactionController do
   use ExMoney.Web, :controller
 
   alias ExMoney.DateHelper
-  alias ExMoney.{Repo, Transaction, Category, Account, TransactionInfo, FavouriteTransaction}
+  alias ExMoney.{Repo, Transaction, Category, Account, FavouriteTransaction}
 
   plug Guardian.Plug.EnsureAuthenticated, handler: ExMoney.Guardian.Mobile.Unauthenticated
   plug :put_layout, "mobile.html"
@@ -177,7 +177,7 @@ defmodule ExMoney.Web.Mobile.TransactionController do
     transaction = Repo.one(
       from tr in Transaction,
         where: tr.id == ^id,
-        preload: [:account, :transaction_info, :category]
+        preload: [:account, :category]
       )
 
     render conn, :show, transaction: transaction
@@ -192,9 +192,6 @@ defmodule ExMoney.Web.Mobile.TransactionController do
         new_balance = Decimal.sub(account.balance, transaction.amount)
 
         Repo.transaction(fn ->
-          tr_info = TransactionInfo.by_transaction_id(id) |> Repo.one
-          if tr_info, do: Repo.delete!(tr_info)
-
           Repo.delete!(transaction)
 
           Account.update_custom_changeset(account, %{balance: new_balance})
@@ -206,9 +203,6 @@ defmodule ExMoney.Web.Mobile.TransactionController do
           new_balance: new_balance
       _ ->
         Repo.transaction(fn ->
-          tr_info = TransactionInfo.by_transaction_id(id) |> Repo.one
-          if tr_info, do: Repo.delete!(tr_info)
-
           Repo.delete!(transaction)
         end)
 

--- a/lib/ex_money/web/controllers/transaction_controller.ex
+++ b/lib/ex_money/web/controllers/transaction_controller.ex
@@ -12,7 +12,7 @@ defmodule ExMoney.Web.TransactionController do
 
     paginator = Transaction.by_user_id(user.id)
     |> order_by(desc: :made_on)
-    |> preload([:transaction_info, :account, :saltedge_account, :category])
+    |> preload([:account, :saltedge_account, :category])
     |> Paginator.paginate(params)
 
     render conn, :index,

--- a/lib/ex_money/web/templates/mobile/transaction/show.html.eex
+++ b/lib/ex_money/web/templates/mobile/transaction/show.html.eex
@@ -40,7 +40,7 @@
           </tbody>
         </table>
       </div>
-      <%= if @transaction.transaction_info do %>
+      <%= if @transaction.extra do %>
         <div class="data-table card">
           <table>
             <tbody>
@@ -49,23 +49,23 @@
               </tr>
               <tr>
                 <td>Payee</td>
-                <td><%= @transaction.transaction_info.payee %></td>
+                <td><%= @transaction.extra["payee"] %></td>
               </tr>
               <tr>
                 <td>Information</td>
-                <td><%= @transaction.transaction_info.information %></td>
+                <td><%= @transaction.extra["information"] %></td>
               </tr>
               <tr>
                 <td>Time</td>
-                <td><%= @transaction.transaction_info.time %></td>
+                <td><%= @transaction.extra["time"] %></td>
               </tr>
               <tr>
                 <td>Posting date</td>
-                <td><%= @transaction.transaction_info.posting_date %></td>
+                <td><%= @transaction.extra["posting_date"] %></td>
               </tr>
               <tr>
                 <td>Posting time</td>
-                <td><%= @transaction.transaction_info.posting_time %></td>
+                <td><%= @transaction.extra["posting_time"] %></td>
               </tr>
             </tbody>
           </table>

--- a/lib/ex_money/web/views/api/v2/transaction_view.ex
+++ b/lib/ex_money/web/views/api/v2/transaction_view.ex
@@ -16,16 +16,8 @@ defmodule ExMoney.Web.Api.V2.TransactionView do
        currency_code: transaction.currency_code,
        description: transaction.description,
        account_id: transaction.account_id,
-       transaction_info: render_one(transaction.transaction_info, TransactionView, "transaction_info.json", as: :transaction_info),
+       extra: transaction.extra,
        category: render_one(transaction.category, TransactionView, "category.json", as: :category)
-     }
-  end
-
-  def render("transaction_info.json", %{transaction_info: transaction_info}) do
-    %{
-       payee: transaction_info.payee,
-       information: transaction_info.information,
-       additional: transaction_info.additional
      }
   end
 

--- a/lib/ex_money/web/views/dashboard_view.ex
+++ b/lib/ex_money/web/views/dashboard_view.ex
@@ -1,16 +1,19 @@
 defmodule ExMoney.Web.DashboardView do
   use ExMoney.Web, :view
 
+  alias ExMoney.Transaction
+
   def balance(transactions) do
     Enum.reduce(transactions, Decimal.new(0), fn(transaction, acc) ->
       Decimal.add(acc, transaction.amount)
     end)
   end
 
+  def description(%Transaction{extra: nil} = transaction) do
+    transaction.description
+  end
+
   def description(transaction) do
-    case transaction.transaction_info do
-      nil -> transaction.description
-      ti -> ti.payee
-    end
+    transaction.extra["payee"]
   end
 end

--- a/lib/ex_money/web/views/mobile/dashboard_view.ex
+++ b/lib/ex_money/web/views/mobile/dashboard_view.ex
@@ -1,29 +1,31 @@
 defmodule ExMoney.Web.Mobile.DashboardView do
   use ExMoney.Web, :view
 
-   def categories_chart_data([]), do: []
+  alias ExMoney.Transaction
 
-   def categories_chart_data(categories) do
-     {_category, _color, max} = Enum.max_by(categories, fn({_category, _color, amount}) -> amount end)
+  def categories_chart_data([]), do: []
 
-     Enum.reduce(categories, [], fn({category, color, amount}, acc) ->
-       percent = (amount * 100) / max
-       |> Float.round(0)
-       |> :erlang.float_to_binary(decimals: 0)
+  def categories_chart_data(categories) do
+    {_category, _color, max} = Enum.max_by(categories, fn({_category, _color, amount}) -> amount end)
 
-       if percent == "0" do
-         acc
-       else
-         [{category, color, "#{percent}%", amount} | acc]
-       end
+    Enum.reduce(categories, [], fn({category, color, amount}, acc) ->
+      percent = (amount * 100) / max
+      |> Float.round(0)
+      |> :erlang.float_to_binary(decimals: 0)
 
-     end)
-     |> Enum.sort(fn(
-       {_cat_1, _color_1, _width_1, amount_1},
-       {_cat_2, _color_2, _width_2, amount_2}) ->
-       amount_1 > amount_2
-     end)
-   end
+      if percent == "0" do
+        acc
+      else
+        [{category, color, "#{percent}%", amount} | acc]
+      end
+
+    end)
+    |> Enum.sort(fn(
+      {_cat_1, _color_1, _width_1, amount_1},
+      {_cat_2, _color_2, _width_2, amount_2}) ->
+      amount_1 > amount_2
+    end)
+  end
 
   def expenses(transactions) do
     Enum.reject(transactions, fn(transaction) ->
@@ -43,11 +45,12 @@ defmodule ExMoney.Web.Mobile.DashboardView do
     end)
   end
 
+  def description(%Transaction{extra: nil} = transaction) do
+    transaction.description
+  end
+
   def description(transaction) do
-    case transaction.transaction_info do
-      nil -> transaction.description
-      ti -> ti.payee
-    end
+    transaction.extra["payee"]
   end
 
   def recent_diff(recent_diff, currency_label) do

--- a/lib/ex_money/web/views/mobile/transaction_view.ex
+++ b/lib/ex_money/web/views/mobile/transaction_view.ex
@@ -1,5 +1,6 @@
 defmodule ExMoney.Web.Mobile.TransactionView do
   use ExMoney.Web, :view
+  alias ExMoney.Transaction
 
   def balance(transactions) do
     Enum.reduce(transactions, Decimal.new(0), fn(transaction, acc) ->
@@ -7,11 +8,12 @@ defmodule ExMoney.Web.Mobile.TransactionView do
     end)
   end
 
+  def description(%Transaction{extra: nil} = transaction) do
+    transaction.description
+  end
+
   def description(transaction) do
-    case transaction.transaction_info do
-      nil -> transaction.description
-      ti -> ti.payee
-    end
+    transaction.extra["payee"]
   end
 
   def render("delete.json", %{account_id: account_id, new_balance: new_balance}) do

--- a/lib/ex_money/web/views/shared_view.ex
+++ b/lib/ex_money/web/views/shared_view.ex
@@ -1,5 +1,6 @@
 defmodule ExMoney.Web.SharedView do
   use ExMoney.Web, :view
+  alias ExMoney.Transaction
 
   def translate_error({message, values}) do
     Enum.reduce values, message, fn {k, v}, acc ->
@@ -15,11 +16,12 @@ defmodule ExMoney.Web.SharedView do
     end)
   end
 
+  def description(%Transaction{extra: nil} = transaction) do
+    transaction.description
+  end
+
   def description(transaction) do
-    case transaction.transaction_info do
-      nil -> transaction.description
-      ti -> ti.payee
-    end
+    transaction.extra["payee"]
   end
 
   def category_name(nil), do: ""

--- a/lib/ex_money/web/views/transaction_view.ex
+++ b/lib/ex_money/web/views/transaction_view.ex
@@ -1,5 +1,6 @@
 defmodule ExMoney.Web.TransactionView do
   use ExMoney.Web, :view
+  alias ExMoney.Transaction
 
   def disabled_previous_page?(page_number, total_pages) do
     if page_number == 1 or total_pages == 1 do
@@ -31,11 +32,12 @@ defmodule ExMoney.Web.TransactionView do
     end
   end
 
+  def payee(%Transaction{extra: nil}) do
+    ""
+  end
+
   def payee(transaction) do
-    case transaction.transaction_info do
-      nil -> ""
-      ti -> ti.payee
-    end
+    transaction.extra["payee"] || ""
   end
 
   def account(transaction) do

--- a/lib/mix/tasks/migrate_transactions_info.ex
+++ b/lib/mix/tasks/migrate_transactions_info.ex
@@ -1,0 +1,29 @@
+defmodule Mix.Tasks.ExMoney.MigrateTransactionsInfo do
+  use Mix.Task
+  import Mix.Ecto
+
+  alias ExMoney.{Repo, Transaction, TransactionInfo}
+
+  @shortdoc "Migrate TransactionsInfo table to 'extra' jsonb column in Transaction"
+
+  def run(_args) do
+    ensure_repo(ExMoney.Repo, [])
+    ensure_started(ExMoney.Repo, [])
+
+    infos = Repo.all(TransactionInfo)
+
+    Enum.each infos, fn(info) ->
+      info_map =
+        info
+        |> Map.from_struct()
+        |> Map.drop([:id, :inserted_at, :__meta__, :updated_at, :transaction_id, :transaction])
+        |> Enum.filter(fn {_, v} -> v != nil end)
+        |> Enum.into(%{})
+
+      transaction = Repo.get(Transaction, info.transaction_id)
+
+      Transaction.update_changeset(transaction, %{extra: info_map})
+      |> Repo.update
+    end
+  end
+end

--- a/priv/repo/migrations/20170725203214_add_info_to_transactions.exs
+++ b/priv/repo/migrations/20170725203214_add_info_to_transactions.exs
@@ -1,0 +1,9 @@
+defmodule ExMoney.Repo.Migrations.AddInfoToTransactions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:transactions) do
+      add :extra, :map
+    end
+  end
+end

--- a/test/lib/rule_processor_test.exs
+++ b/test/lib/rule_processor_test.exs
@@ -136,7 +136,7 @@ defmodule ExMoney.RuleProcessorTest do
         saltedge_account_id: rule.account.saltedge_account_id
       )
       tr_2 = insert(:transaction,
-        transaction_info: build(:transaction_info, payee: "foo"),
+        extra: %{payee: "foo"},
         account: rule.account,
         saltedge_account_id: rule.account.saltedge_account_id
       )

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -53,13 +53,8 @@ defmodule ExMoney.Factory do
       saltedge_account_id: account.saltedge_account_id,
       account: account,
       user: build(:user),
-      category: build(:category),
-      transaction_info: build(:transaction_info)
+      category: build(:category)
     }
-  end
-
-  def transaction_info_factory do
-    %ExMoney.TransactionInfo{}
   end
 
   def category_factory do


### PR DESCRIPTION
Heroku today sent me a notification which says that my postgres db has ~8k rows out of 10k rows allowed on free plan. So I came up with a simple solution how to remove ~2k rows. In fact, storing `extra` as `jsonb` even simplified the code in some places. The next step would be to get rid of `accounts_balance_history` table somehow.
In order to migrate existing entries in `transactions_info` table, 
run `heroku run mix ex_money.migrate_transactions_info`.