### PR TITLE
Properly exit from `create_from_fav` view

### DIFF
--- a/lib/ex_money_web/controllers/mobile/transaction_controller.ex
+++ b/lib/ex_money_web/controllers/mobile/transaction_controller.ex
@@ -145,6 +145,10 @@ defmodule ExMoney.Web.Mobile.TransactionController do
     send_resp(conn, 200, "")
   end
 
+  def create_from_fav(conn, %{"transaction[amount]" => ""}) do
+    send_resp(conn, 200, "")
+  end
+
   def create_from_fav(conn, params) do
     amount =  params["transaction[amount]"]
     fav_tr_id = params["transaction[fav_tr_id]"]


### PR DESCRIPTION
Currently there is no way to exit from `create_from_fav` view (when you create your fav transaction). 
Now when you tap `Done` without entering any amount, you close this popup.