### PR TITLE
Show limit border when it's exceeded

### DIFF
--- a/lib/ex_money_web/views/mobile/budget_view.ex
+++ b/lib/ex_money_web/views/mobile/budget_view.ex
@@ -29,6 +29,21 @@ defmodule ExMoney.Web.Mobile.BudgetView do
     """
   end
 
+  def build_linear_gradient(%{limit: limit, amount: amount} = category) when not is_nil(limit) and amount > limit do
+    """
+    background: linear-gradient(
+      to right,
+      #{category[:css_color]} calc(#{category[:limit_percent]}),
+      #{category[:css_color]} calc(#{category[:limit_percent]} - 1px),
+      coral calc(#{category[:limit_percent]} + 5px),
+      #{category[:css_color]} calc(#{category[:limit_percent]} + 1px),
+      #{category[:css_color]} calc(#{category[:width]}),
+      whitesmoke calc(#{category[:width]} + 1px),
+      whitesmoke calc(100%)
+    )
+    """
+  end
+
   def build_linear_gradient(%{limit: limit} = category) when not is_nil(limit) do
     """
     background: linear-gradient(


### PR DESCRIPTION
Currently on budget page when category limit is exceeded the special red border is not visible. 
This PR fixes that.

Before 
<img width="284" alt="screen shot 2017-10-21 at 16 36 53" src="https://user-images.githubusercontent.com/1541059/31852765-16bca7c6-b67e-11e7-8efe-68d5ffef684f.png">

After
<img width="282" alt="screen shot 2017-10-21 at 16 35 57" src="https://user-images.githubusercontent.com/1541059/31852766-1a25d7b6-b67e-11e7-8628-6b422d65061e.png">
