### PR TITLE
Fix budget expenses view

### DIFF
--- a/lib/ex_money_web/models/transaction.ex
+++ b/lib/ex_money_web/models/transaction.ex
@@ -157,9 +157,9 @@ defmodule ExMoney.Transaction do
       where: tr.made_on >= ^from,
       where: tr.made_on <= ^to,
       where: tr.account_id in ^account_ids,
+      where: tr.amount < 0,
       group_by: [c.id],
-      select: {c, sum(tr.amount)},
-      having: sum(tr.amount) < 0
+      select: {c, sum(tr.amount)}
   end
 
   def group_by_month_by_category(account_id, from, to) do


### PR DESCRIPTION
It's kinda stupid to calculate total sum of all transactions amounts per category and then display it as 'Top Expenses' view. In such case if there are two transactions with the same category, where one of them has amount -1000 and another one has +1001, then such category wouldn't appear in 'Top Expenses' view on Budget page.

This PR fixes that.